### PR TITLE
Add f32 values in bbox debug print

### DIFF
--- a/savant_core/src/atomic_f32.rs
+++ b/savant_core/src/atomic_f32.rs
@@ -1,6 +1,7 @@
 use std::sync::atomic::{AtomicU32, Ordering};
+use std::fmt;
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize)]
 pub struct AtomicF32(AtomicU32);
 
 impl PartialEq for AtomicF32 {
@@ -39,5 +40,11 @@ impl From<f32> for AtomicF32 {
 impl From<AtomicF32> for f32 {
     fn from(value: AtomicF32) -> Self {
         value.get()
+    }
+}
+
+impl fmt::Debug for AtomicF32 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.get())
     }
 }

--- a/savant_core/src/primitives/bbox.rs
+++ b/savant_core/src/primitives/bbox.rs
@@ -9,6 +9,7 @@ use lazy_static::lazy_static;
 use std::f32::consts::PI;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::fmt;
 
 pub const BBOX_ELEMENT_UNDEFINED: f32 = 3.402_823_5e38_f32;
 
@@ -96,8 +97,20 @@ impl From<&RBBox> for RBBoxData {
 
 /// Represents a bounding box with an optional rotation angle in degrees.
 ///
-#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Clone)]
 pub struct RBBox(Arc<RBBoxData>);
+
+impl fmt::Debug for RBBox {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RBBox")
+         .field("xc", &self.get_xc())
+         .field("yc", &self.get_yc())
+         .field("width", &self.get_width())
+         .field("height", &self.get_height())
+         .field("angle", &self.get_angle())
+         .finish()
+    }
+}
 
 impl PartialEq for RBBox {
     fn eq(&self, other: &Self) -> bool {


### PR DESCRIPTION
Currently the BBox / RBBox debug print from python produces unhelpful AtomicF32 values. This PR aims to improve debug print by showing the decoded float values.