### PR TITLE
Message retrieval improvement

### DIFF
--- a/services/replay/replaydb/src/job.rs
+++ b/services/replay/replaydb/src/job.rs
@@ -193,25 +193,44 @@ where
         })
     }
 
-    async fn read_message(&self) -> Result<(Message, Vec<Vec<u8>>)> {
+    async fn read_message(&mut self) -> Result<(Message, Vec<Vec<u8>>)> {
         let now = Instant::now();
+
         loop {
-            let message = self
+            let message_opt = self
                 .store
                 .lock()
                 .await
                 .get_message(&self.configuration.stored_stream_id, self.position)
                 .await?;
+
+            // the code must be positioned here to avoid the impact of "continue" coming later.
+            // so, even if the message is retrieved, it will be skipped if the idle time is exceeded.
+            //
             if now.elapsed() > self.configuration.max_idle_duration {
                 let log_message = format!(
-                    "No message received during the configured {} idle time (ms). Job Id: {} will be finished!",
-                    self.configuration.max_idle_duration.as_millis(),
-                    Uuid::from_u128(self.id)
-                );
+                        "No message received during the configured {} idle time (ms). Job Id: {} will be finished!",
+                        self.configuration.max_idle_duration.as_millis(),
+                        Uuid::from_u128(self.id)
+                    );
                 warn!(target: "replay::db::job::read_message", "{}", &log_message);
                 bail!("{}", log_message);
             }
-            match message {
+
+            let current_position = self
+                .store
+                .lock()
+                .await
+                .current_index_value(&self.configuration.stored_stream_id)?;
+
+            // we read historical messages but cannot get them, thus they may be expired,
+            // so we skip them and move to the next one
+            if message_opt.is_none() && self.position < current_position {
+                self.position += 1;
+                continue;
+            }
+
+            match message_opt {
                 Some((m, _, data)) => {
                     return Ok((m, data));
                 }
@@ -531,10 +550,8 @@ where
 
             let sliced_data = data.iter().map(|d| d.as_slice()).collect::<Vec<_>>();
 
-            //let send_measurement = Instant::now();
             self.send_either(SendEither::Message(&message, &sliced_data))
                 .await?;
-            //dbg!(send_measurement.elapsed());
 
             self.position += 1;
 
@@ -580,9 +597,14 @@ mod tests {
 
     struct MockStore {
         pub messages: Vec<(Option<(Message, Vec<u8>, Vec<Vec<u8>>)>, Duration)>,
+        pub current_index: usize,
     }
 
     impl Store for MockStore {
+        fn current_index_value(&mut self, _source_id: &str) -> Result<usize> {
+            Ok(self.messages.len())
+        }
+
         async fn add_message(
             &mut self,
             _message: &Message,
@@ -597,10 +619,11 @@ mod tests {
             _source_id: &str,
             _id: usize,
         ) -> Result<Option<(Message, Vec<u8>, Vec<Vec<u8>>)>> {
-            let (m, d) = self.messages.remove(0);
-            tokio_timerfd::sleep(d).await?;
+            let (m, d) = self.messages.get(self.current_index).unwrap();
+            self.current_index += 1;
+            tokio_timerfd::sleep(*d).await?;
             //dbg!("get_message", self.messages.len(), systime_ms());
-            Ok(m)
+            Ok(m.clone())
         }
 
         async fn get_first(
@@ -676,6 +699,7 @@ mod tests {
         let f0 = gen_properly_filled_frame(true);
         let f0_uuid = f0.get_uuid();
         let store = MockStore {
+            current_index: 0,
             messages: vec![
                 (
                     Some((f0.to_message(), vec![], vec![])),
@@ -697,7 +721,7 @@ mod tests {
             .max_idle_duration(Duration::from_millis(50))
             .build_and_validate()?;
 
-        let job = Job::new(
+        let mut job = Job::new(
             store,
             w.clone(),
             Uuid::from_u128(0),
@@ -726,6 +750,7 @@ mod tests {
         let f0 = gen_properly_filled_frame(true);
         let f0_uuid = f0.get_uuid();
         let store = MockStore {
+            current_index: 0,
             messages: vec![
                 (None, Duration::from_millis(10)),
                 (None, Duration::from_millis(10)),
@@ -745,7 +770,7 @@ mod tests {
             .max_idle_duration(Duration::from_millis(50))
             .build_and_validate()?;
 
-        let job = Job::new(
+        let mut job = Job::new(
             store,
             w.clone(),
             Uuid::from_u128(0),
@@ -771,7 +796,10 @@ mod tests {
     async fn test_prepare_message() -> Result<()> {
         let (r, w) = get_channel().await?;
 
-        let store = MockStore { messages: vec![] };
+        let store = MockStore {
+            current_index: 0,
+            messages: vec![],
+        };
         let store = Arc::new(Mutex::new(store));
 
         let job_conf = JobConfigurationBuilder::default()
@@ -827,7 +855,10 @@ mod tests {
     async fn test_prepare_message_skip_intermediary_eos() -> Result<()> {
         let (r, w) = get_channel().await?;
 
-        let store = MockStore { messages: vec![] };
+        let store = MockStore {
+            current_index: 0,
+            messages: vec![],
+        };
         let store = Arc::new(Mutex::new(store));
 
         let job_conf = JobConfigurationBuilder::default()
@@ -869,7 +900,10 @@ mod tests {
     async fn test_check_discrepant_pts() -> Result<()> {
         let (r, w) = get_channel().await?;
 
-        let store = MockStore { messages: vec![] };
+        let store = MockStore {
+            current_index: 0,
+            messages: vec![],
+        };
         let store = Arc::new(Mutex::new(store));
 
         let job_conf = JobConfigurationBuilder::default()
@@ -920,7 +954,10 @@ mod tests {
     async fn test_check_discrepant_pts_stop_when_incorrect() -> Result<()> {
         let (r, w) = get_channel().await?;
 
-        let store = MockStore { messages: vec![] };
+        let store = MockStore {
+            current_index: 0,
+            messages: vec![],
+        };
         let store = Arc::new(Mutex::new(store));
 
         let job_conf = JobConfigurationBuilder::default()
@@ -962,7 +999,10 @@ mod tests {
     async fn test_send_either() -> Result<()> {
         let (r, w) = get_channel().await?;
 
-        let store = MockStore { messages: vec![] };
+        let store = MockStore {
+            current_index: 0,
+            messages: vec![],
+        };
         let store = Arc::new(Mutex::new(store));
 
         let job_conf = JobConfigurationBuilder::default()
@@ -1005,7 +1045,10 @@ mod tests {
     async fn test_send_either_timeout() -> Result<()> {
         let (mut r, w) = get_channel().await?;
 
-        let store = MockStore { messages: vec![] };
+        let store = MockStore {
+            current_index: 0,
+            messages: vec![],
+        };
         let store = Arc::new(Mutex::new(store));
 
         let job_conf = JobConfigurationBuilder::default()
@@ -1049,6 +1092,7 @@ mod tests {
         ];
 
         let store = MockStore {
+            current_index: 0,
             messages: frames
                 .iter()
                 .map(|f| {
@@ -1111,6 +1155,7 @@ mod tests {
         }
         //dbg!("frames filled", thread_now.elapsed(),);
         let store = MockStore {
+            current_index: 0,
             messages: frames
                 .iter()
                 .map(|f| {
@@ -1180,6 +1225,7 @@ mod tests {
         let last_uuid: u128;
         let first_uuid: Uuid;
         let store = MockStore {
+            current_index: 0,
             messages: vec![
                 (
                     {
@@ -1284,6 +1330,7 @@ mod tests {
         }
 
         let store = MockStore {
+            current_index: 0,
             messages: frames
                 .iter()
                 .map(|f| {
@@ -1357,6 +1404,7 @@ mod tests {
         }
 
         let store = MockStore {
+            current_index: 0,
             messages: frames
                 .iter()
                 .map(|f| {
@@ -1441,6 +1489,7 @@ mod tests {
         ];
 
         let store = MockStore {
+            current_index: 0,
             messages: frames
                 .iter()
                 .map(|f| {
@@ -1503,7 +1552,10 @@ mod tests {
     async fn test_json() -> Result<()> {
         let (r, w) = get_channel().await?;
 
-        let store = MockStore { messages: vec![] };
+        let store = MockStore {
+            current_index: 0,
+            messages: vec![],
+        };
         let store = Arc::new(Mutex::new(store));
 
         let job_conf = JobConfigurationBuilder::default()
@@ -1546,6 +1598,56 @@ mod tests {
                 serde_json::to_string(&RoutingLabelsUpdateStrategy::Append(vec![]))?
             ]
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_future_message() -> Result<()> {
+        let (_, w) = get_channel().await?;
+
+        let first_frame = gen_properly_filled_frame(true);
+        let last_frame = gen_properly_filled_frame(true);
+        let store = MockStore {
+            current_index: 0,
+            messages: vec![
+                (
+                    Some((first_frame.to_message(), vec![], vec![])),
+                    Duration::from_secs(0),
+                ),
+                (None, Duration::from_secs(0)),
+                (None, Duration::from_secs(0)),
+                (None, Duration::from_secs(0)),
+                (None, Duration::from_secs(0)),
+                (
+                    Some((last_frame.to_message(), vec![], vec![])),
+                    Duration::from_secs(0),
+                ),
+            ],
+        };
+        let store = Arc::new(Mutex::new(store));
+
+        let job_conf = JobConfigurationBuilder::default()
+            .routing_labels(RoutingLabelsUpdateStrategy::Bypass)
+            .stored_stream_id("source_id".to_string())
+            .resulting_stream_id("resulting_id".to_string())
+            .max_idle_duration(Duration::from_millis(50))
+            .build_and_validate()?;
+
+        let mut job = Job::new(
+            store,
+            w.clone(),
+            Uuid::default(),
+            incremental_uuid_v7(),
+            Duration::from_millis(50),
+            JobOffset::Seconds(1.0),
+            JobStopCondition::last_frame(last_frame.get_uuid_u128()),
+            job_conf,
+            None,
+        )?;
+        let now = tokio::time::Instant::now();
+        let _first = job.read_message().await?;
+        let _second = job.read_message().await?;
+        assert!(now.elapsed() < Duration::from_millis(1));
         Ok(())
     }
 }

--- a/services/replay/replaydb/src/store.rs
+++ b/services/replay/replaydb/src/store.rs
@@ -50,7 +50,7 @@ pub(crate) trait Store {
     async fn get_message(
         &mut self,
         source_id: &str,
-        position: usize,
+        index: usize,
     ) -> Result<Option<(Message, Vec<u8>, Vec<Vec<u8>>)>>;
 
     async fn get_first(

--- a/services/replay/replaydb/src/store.rs
+++ b/services/replay/replaydb/src/store.rs
@@ -37,6 +37,8 @@ pub enum JobOffset {
 pub type SyncRocksDbStore = Arc<Mutex<rocksdb::RocksDbStore>>;
 
 pub(crate) trait Store {
+    fn current_index_value(&mut self, source_id: &str) -> Result<usize>;
+
     async fn add_message(
         &mut self,
         message: &Message,
@@ -48,7 +50,7 @@ pub(crate) trait Store {
     async fn get_message(
         &mut self,
         source_id: &str,
-        id: usize,
+        position: usize,
     ) -> Result<Option<(Message, Vec<u8>, Vec<Vec<u8>>)>>;
 
     async fn get_first(
@@ -79,6 +81,10 @@ mod tests {
     }
 
     impl Store for SampleStore {
+        fn current_index_value(&mut self, _source_id: &str) -> Result<usize> {
+            Ok(self.messages.len())
+        }
+
         async fn add_message(
             &mut self,
             message: &Message,

--- a/services/replay/replaydb/src/store/rocksdb.rs
+++ b/services/replay/replaydb/src/store/rocksdb.rs
@@ -252,16 +252,16 @@ impl super::Store for RocksDbStore {
     async fn get_message(
         &mut self,
         source_id: &str,
-        position: usize,
+        index: usize,
     ) -> Result<Option<(Message, Vec<u8>, Vec<Vec<u8>>)>> {
         let current_index = self.current_index_value(source_id)?;
-        if position > current_index {
+        if index > current_index {
             return Ok(None);
         }
         let source_hash = self.get_source_hash(source_id)?;
         let key = MessageKey {
             source_md5: source_hash,
-            index: position,
+            index,
         };
         let key_bytes = bincode::encode_to_vec(key, self.configuration)?;
         let cf = self

--- a/services/replay/replaydb/src/store/rocksdb.rs
+++ b/services/replay/replaydb/src/store/rocksdb.rs
@@ -93,29 +93,6 @@ impl RocksDbStore {
         Ok(hash_bytes)
     }
 
-    fn current_index_value(&mut self, source_id: &str) -> Result<usize> {
-        if let Some(index) = self.resident_index_values.get(source_id) {
-            return Ok(*index);
-        }
-
-        let key = IndexKey {
-            source_md5: self.get_source_hash(source_id)?,
-        };
-
-        let key_bytes = bincode::encode_to_vec(key, self.configuration)?;
-        let cf = self.db.cf_handle(CF_INDEX_DB).unwrap();
-        let value_bytes = self.db.get_cf(cf, key_bytes)?;
-        let value = if let Some(value_bytes) = value_bytes {
-            let value: IndexValue = bincode::decode_from_slice(&value_bytes, self.configuration)?.0;
-            value.index
-        } else {
-            0
-        };
-
-        self.resident_index_values
-            .insert(source_id.to_string(), value);
-        Ok(value)
-    }
     pub fn new(path: &Path, ttl: Duration) -> Result<Self> {
         let configuration = bincode::config::standard().with_big_endian();
 
@@ -166,6 +143,30 @@ impl RocksDbStore {
 }
 
 impl super::Store for RocksDbStore {
+    fn current_index_value(&mut self, source_id: &str) -> Result<usize> {
+        if let Some(index) = self.resident_index_values.get(source_id) {
+            return Ok(*index);
+        }
+
+        let key = IndexKey {
+            source_md5: self.get_source_hash(source_id)?,
+        };
+
+        let key_bytes = bincode::encode_to_vec(key, self.configuration)?;
+        let cf = self.db.cf_handle(CF_INDEX_DB).unwrap();
+        let value_bytes = self.db.get_cf(cf, key_bytes)?;
+        let value = if let Some(value_bytes) = value_bytes {
+            let value: IndexValue = bincode::decode_from_slice(&value_bytes, self.configuration)?.0;
+            value.index
+        } else {
+            0
+        };
+
+        self.resident_index_values
+            .insert(source_id.to_string(), value);
+        Ok(value)
+    }
+
     async fn add_message(
         &mut self,
         message: &Message,
@@ -251,12 +252,16 @@ impl super::Store for RocksDbStore {
     async fn get_message(
         &mut self,
         source_id: &str,
-        id: usize,
+        position: usize,
     ) -> Result<Option<(Message, Vec<u8>, Vec<Vec<u8>>)>> {
+        let current_index = self.current_index_value(source_id)?;
+        if position > current_index {
+            return Ok(None);
+        }
         let source_hash = self.get_source_hash(source_id)?;
         let key = MessageKey {
             source_md5: source_hash,
-            index: id,
+            index: position,
         };
         let key_bytes = bincode::encode_to_vec(key, self.configuration)?;
         let cf = self
@@ -591,6 +596,26 @@ mod tests {
         let res_keyframes = db.find_keyframes(&source, None, None, 2).await?;
         assert_eq!(res_keyframes.len(), 2);
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_future_message() -> Result<()> {
+        let dir = tempfile::TempDir::new()?;
+        let path = dir.path();
+        let mut db = RocksDbStore::new(path, Duration::from_secs(60))?;
+        let source_id = "test_source_id";
+        let message = gen_properly_filled_frame(true).to_message();
+        db.add_message(&message, &[], &[]).await?;
+        let message = gen_properly_filled_frame(true).to_message();
+        db.add_message(&message, &[], &[]).await?;
+
+        let now = std::time::Instant::now();
+        let res = db.get_message(source_id, 10).await?;
+        let elapsed = now.elapsed();
+        assert!(res.is_none());
+        // Should return very quickly, under 1ms
+        assert!(elapsed.as_millis() < 1);
         Ok(())
     }
 }


### PR DESCRIPTION
Improved message retrieval procedure by optimizing reading future and previous frames.

* For frames in the future: if the frame is in the future, do not try reading; just wait until it becomes available.
* For the past frames: if reading a past frame returns None, it means that the frame is expired and we must go forward instead of waiting for it.