### PR TITLE
Pipeline support in the Replay service

### DIFF
--- a/savant_core/src/metrics/pipeline_metric_builder.rs
+++ b/savant_core/src/metrics/pipeline_metric_builder.rs
@@ -1,6 +1,6 @@
 use crate::metrics::{get_or_create_counter_family, get_or_create_gauge_family};
+use crate::pipeline::get_registered_pipelines;
 use crate::rust::FrameProcessingStatRecordType;
-use crate::webserver::get_registered_pipelines;
 use log::debug;
 
 #[derive(Debug)]
@@ -29,7 +29,7 @@ impl PipelineMetricBuilder {
         let stage_latency_label_names =
             ["record_type", "destination_stage_name", "source_stage_name"].as_slice();
 
-        let registered_pipelines = get_registered_pipelines().await;
+        let registered_pipelines = get_registered_pipelines();
         debug!(
             "Found {} registered pipeline(s)",
             registered_pipelines.len()

--- a/savant_core/src/telemetry.rs
+++ b/savant_core/src/telemetry.rs
@@ -1,4 +1,3 @@
-use crate::get_or_init_async_runtime;
 use log::error;
 use opentelemetry::global;
 use opentelemetry_jaeger_propagator::Propagator;
@@ -251,8 +250,7 @@ pub fn init(config: &TelemetryConfiguration) {
     match configurator.get() {
         Some(_) => panic!("Open Telemetry has been configured"),
         None => {
-            let runtime = get_or_init_async_runtime();
-            let c = runtime.block_on(async { Configurator::new("savant", config) });
+            let c = Configurator::new("savant", config);
             let result = configurator.set(c);
             if result.is_err() {
                 // should not happen

--- a/services/replay/replay/assets/test.json
+++ b/services/replay/replay/assets/test.json
@@ -29,7 +29,13 @@
       "send_hwm": 1000,
       "receive_hwm": 100,
       "inflight_ops": 100
-    }
+    },
+    "stats_frame_period": null,
+    "stats_timestamp_period": {
+      "secs": 10,
+      "nanos": 0
+    },
+    "telemetry_config_file": null
   },
   "in_stream": {
     "url": "router+bind:ipc:///tmp/${SOCKET_PATH_IN:-undefined}",

--- a/services/replay/replaydb/Cargo.toml
+++ b/services/replay/replaydb/Cargo.toml
@@ -20,6 +20,7 @@ bincode = { workspace = true }
 derive_builder = { workspace = true }
 env_logger = { workspace = true }
 hashbrown = { workspace = true }
+lazy_static = { workspace = true }
 log = { workspace = true }
 md-5 = { workspace = true }
 mini-moka = { workspace = true }

--- a/services/replay/replaydb/assets/rocksdb.json
+++ b/services/replay/replaydb/assets/rocksdb.json
@@ -14,7 +14,13 @@
     "job_eviction_ttl": {
       "secs": 60,
       "nanos": 0
-    }
+    },
+    "stats_frame_period": null,
+    "stats_timestamp_period": {
+      "secs": 10,
+      "nanos": 0
+    },
+    "telemetry_config_file": null
   },
   "in_stream": {
     "url": "router+bind:ipc:///tmp/${SOCKET_PATH_IN:-undefined}",

--- a/services/replay/replaydb/assets/rocksdb_opt_out.json
+++ b/services/replay/replaydb/assets/rocksdb_opt_out.json
@@ -14,7 +14,13 @@
     "job_eviction_ttl": {
       "secs": 60,
       "nanos": 0
-    }
+    },
+    "stats_frame_period": null,
+    "stats_timestamp_period": {
+      "secs": 10,
+      "nanos": 0
+    },
+    "telemetry_config_file": null
   },
   "in_stream": {
     "url": "router+bind:ipc:///tmp/${SOCKET_PATH_IN:-undefined}",

--- a/services/replay/replaydb/src/service/configuration.rs
+++ b/services/replay/replaydb/src/service/configuration.rs
@@ -1,6 +1,9 @@
 use crate::job_writer::{SinkConfiguration, SinkOptions};
 use anyhow::{bail, Result};
-use savant_core::transport::zeromq::{NonBlockingReader, ReaderConfigBuilder};
+use savant_core::{
+    telemetry::init_from_file,
+    transport::zeromq::{NonBlockingReader, ReaderConfigBuilder},
+};
 use serde::{Deserialize, Serialize};
 use std::result;
 use std::time::Duration;
@@ -50,6 +53,9 @@ pub struct CommonConfiguration {
     pub job_writer_cache_ttl: Duration,
     pub job_eviction_ttl: Duration,
     pub default_job_sink_options: Option<SinkOptions>,
+    pub telemetry_config_file: Option<String>,
+    pub stats_frame_period: Option<i64>,
+    pub stats_timestamp_period: Option<Duration>,
 }
 
 #[config]
@@ -65,6 +71,9 @@ impl ServiceConfiguration {
     pub(crate) fn validate(&self) -> Result<()> {
         if self.common.management_port <= 1024 {
             bail!("Management port must be set to a value greater than 1024!");
+        }
+        if let Some(telemetry_config_file) = &self.common.telemetry_config_file {
+            init_from_file(telemetry_config_file.as_str());
         }
         Ok(())
     }

--- a/services/replay/replaydb/src/service/rocksdb_service.rs
+++ b/services/replay/replaydb/src/service/rocksdb_service.rs
@@ -72,6 +72,11 @@ impl TryFrom<&ServiceConfiguration> for RocksDbStreamProcessor {
             output,
             configuration.common.stats_period,
             configuration.common.pass_metadata_only,
+            configuration.common.stats_frame_period,
+            configuration
+                .common
+                .stats_timestamp_period
+                .map(|d| d.as_millis() as i64),
         ))
     }
 }

--- a/services/replay/replaydb/src/stream_processor.rs
+++ b/services/replay/replaydb/src/stream_processor.rs
@@ -3,6 +3,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::{bail, Result};
 use savant_core::message::Message;
+use savant_core::pipeline::{Pipeline, PipelineConfigurationBuilder, PipelineStagePayloadType};
 use savant_core::transport::zeromq::{
     NonBlockingReader, NonBlockingWriter, ReaderResult, WriterResult,
 };
@@ -27,6 +28,7 @@ struct StreamProcessor<T: Store> {
     stats_period: Duration,
     send_metadata_only: bool,
     stop_flag: bool,
+    pipeline: Pipeline,
 }
 
 impl<T> StreamProcessor<T>
@@ -39,8 +41,42 @@ where
         output: Option<NonBlockingWriter>,
         stats_period: Duration,
         send_metadata_only: bool,
-    ) -> Self {
-        Self {
+        frame_period: Option<i64>,
+        timestamp_period: Option<i64>,
+    ) -> Result<Self> {
+        let conf = PipelineConfigurationBuilder::default()
+            .frame_period(frame_period)
+            .timestamp_period(timestamp_period)
+            .build()
+            .expect("Failed to build pipeline configuration");
+
+        let pipeline = Pipeline::new(
+            "replay",
+            vec![
+                (
+                    "store".to_string(),
+                    PipelineStagePayloadType::Frame,
+                    None,
+                    None,
+                ),
+                (
+                    "egress".to_string(),
+                    PipelineStagePayloadType::Frame,
+                    None,
+                    None,
+                ),
+                (
+                    "cleanup".to_string(),
+                    PipelineStagePayloadType::Frame,
+                    None,
+                    None,
+                ),
+            ],
+            conf,
+        )
+        .expect("Failed to create pipeline");
+
+        Ok(Self {
             db,
             input,
             output,
@@ -52,7 +88,8 @@ where
             last_stats: Instant::now(),
             send_metadata_only,
             stop_flag: false,
-        }
+            pipeline,
+        })
     }
 
     async fn receive_message(&mut self) -> Result<ReaderResult> {
@@ -147,6 +184,16 @@ where
                     routing_id,
                     data,
                 } => {
+                    let frame_id = if message.is_video_frame() {
+                        let context = message.get_span_context().extract();
+                        Some(self.pipeline.add_frame_with_telemetry(
+                            "store",
+                            message.as_video_frame().unwrap(),
+                            context,
+                        )?)
+                    } else {
+                        None
+                    };
                     self.stats.packet_counter += 1;
                     self.stats.byte_counter += data.iter().map(|v| v.len() as u64).sum::<u64>();
                     log::debug!(
@@ -169,6 +216,9 @@ where
                             .await
                             .add_message(&message, &topic, &data)
                             .await?;
+                        if let Some(frame_id) = frame_id {
+                            self.pipeline.move_as_is("egress", vec![frame_id])?;
+                        }
                     }
                     let data_slice = if self.send_metadata_only {
                         vec![]
@@ -178,6 +228,10 @@ where
 
                     self.send_message(std::str::from_utf8(&topic)?, &message, &data_slice)
                         .await?;
+                    if let Some(frame_id) = frame_id {
+                        self.pipeline.move_as_is("cleanup", vec![frame_id])?;
+                        self.pipeline.delete(frame_id)?;
+                    }
                 }
                 ReaderResult::Timeout => {
                     log::debug!(
@@ -251,14 +305,21 @@ impl RocksDbStreamProcessor {
         output: Option<NonBlockingWriter>,
         stats_period: Duration,
         send_metadata_only: bool,
+        stats_frame_period: Option<i64>,
+        stats_timestamp_period: Option<i64>,
     ) -> Self {
-        Self(StreamProcessor::new(
-            db,
-            input,
-            output,
-            stats_period,
-            send_metadata_only,
-        ))
+        Self(
+            StreamProcessor::new(
+                db,
+                input,
+                output,
+                stats_period,
+                send_metadata_only,
+                stats_frame_period,
+                stats_timestamp_period,
+            )
+            .unwrap(),
+        )
     }
 
     pub async fn run_once(&mut self) -> Result<()> {
@@ -360,7 +421,10 @@ mod tests {
             Some(out_writer),
             Duration::from_secs(30),
             false,
-        );
+            None,
+            None,
+        )
+        .unwrap();
 
         let f = gen_properly_filled_frame(true);
         let uuid = f.get_uuid_u128();
@@ -396,6 +460,12 @@ mod tests {
             ReaderResult::TooShort(_) => {
                 panic!("Too short");
             }
+            ReaderResult::MessageVersionMismatch {
+                topic,
+                routing_id,
+                sender_version,
+                expected_version,
+            } => panic!("Message version mismatch: topic: {:?}, routing_id: {:?}, sender_version: {:?}, expected_version: {:?}", topic, routing_id, sender_version, expected_version),
         }
         Ok(())
     }

--- a/services/replay/samples/file_restreaming/README.md
+++ b/services/replay/samples/file_restreaming/README.md
@@ -58,7 +58,7 @@ We are going to use the file source adapter to ingest the video file to Replay.
 docker run --rm -it --name source-video-files-test \
     --network host \
     -e FILE_TYPE=video \
-    -e SYNC_OUTPUT=False \
+    -e SYNC_OUTPUT=True \
     -e ZMQ_ENDPOINT=dealer+connect:tcp://127.0.0.1:5555 \
     -e SOURCE_ID=in-video \
     -e LOCATION=/data/shuffle_dance.mp4 \

--- a/services/replay/samples/file_restreaming/replay_config.json
+++ b/services/replay/samples/file_restreaming/replay_config.json
@@ -29,7 +29,12 @@
       "send_hwm": 1000,
       "receive_hwm": 100,
       "inflight_ops": 100
-    }
+    },
+    "stats_timestamp_period": {
+      "secs": 10,
+      "nanos": 0
+    },
+    "telemetry_config_file": null
   },
   "in_stream": {
     "url": "router+bind:tcp://127.0.0.1:5555",


### PR DESCRIPTION
Refactored pipeline registry storage: 

moved from Tokio async mutexes to sync, 
moved the functions to the proper namespace.

Implemented pipeline support in the Replay service.