### PR TITLE
Add more configurable parameters for rocksdb storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ Cargo.lock
 
 .zed
 .vscode
+
+services/replay/samples/file_restreaming/data

--- a/docs/source/services/replay/2_installation.rst
+++ b/docs/source/services/replay/2_installation.rst
@@ -284,6 +284,22 @@ Configuration Parameters
       - The maximum size of the write-ahead log (WAL) for the RocksDB storage.
       - ``1024 * 1024 * 1024``
       - ``2097152``
+    * - ``storage.rocksdb.disable_wal``
+      - If set to ``true``, Replay will disable the write-ahead log (WAL) for the RocksDB storage.
+      - ``false``
+      - ``true``
+    * - ``storage.rocksdb.compaction_style``
+      - The compaction style for the RocksDB storage, one of ``level``, ``universal``, ``fifo``.
+      - ``"universal"``
+      - ``"fifo"``
+    * - ``storage.rocksdb.max_log_file_size``
+      - The maximum size of the log file for the RocksDB storage.
+      - ``1024 * 1024 * 1024``
+      - ``2097152``
+    * - ``storage.rocksdb.keep_log_file_num``
+      - The number of log files to keep in the RocksDB storage.
+      - ``1000``
+      - ``10``
 
 Environment Variables in Configuration File
 -------------------------------------------

--- a/services/replay/replaydb/src/service/configuration.rs
+++ b/services/replay/replaydb/src/service/configuration.rs
@@ -5,18 +5,61 @@ use savant_services_common::{
     source::SourceConfiguration,
 };
 use serde::{Deserialize, Serialize};
-use std::time::Duration;
+use std::{path::PathBuf, time::Duration};
 use twelf::{config, Layer};
 
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub enum CompactionStyle {
+    #[serde(rename = "level")]
+    Level,
+    #[serde(rename = "universal")]
+    Universal,
+    #[serde(rename = "fifo")]
+    Fifo,
+}
+
+impl Default for CompactionStyle {
+    fn default() -> Self {
+        CompactionStyle::Universal
+    }
+}
+
+impl CompactionStyle {
+    pub fn to_rocksdb_compaction_style(&self) -> rocksdb::DBCompactionStyle {
+        match self {
+            CompactionStyle::Level => rocksdb::DBCompactionStyle::Level,
+            CompactionStyle::Universal => rocksdb::DBCompactionStyle::Universal,
+            CompactionStyle::Fifo => rocksdb::DBCompactionStyle::Fifo,
+        }
+    }
+}
+
 const MAX_TOTAL_WAL_SIZE: u64 = 1024 * 1024 * 1024;
+
+fn default_max_total_wal_size() -> u64 {
+    MAX_TOTAL_WAL_SIZE
+}
+
+fn default_keep_log_file_num() -> usize {
+    1000
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum Storage {
     #[serde(rename = "rocksdb")]
     RocksDB {
-        path: String,
+        path: PathBuf,
         data_expiration_ttl: Duration,
-        max_total_wal_size: Option<u64>,
+        #[serde(default)]
+        disable_wal: bool,
+        #[serde(default = "default_max_total_wal_size")]
+        max_total_wal_size: u64,
+        #[serde(default)]
+        compaction_style: CompactionStyle,
+        #[serde(default)]
+        max_log_file_size: usize,
+        #[serde(default = "default_keep_log_file_num")]
+        keep_log_file_num: usize,
     },
 }
 
@@ -46,12 +89,17 @@ impl ServiceConfiguration {
             Storage::RocksDB {
                 path: _,
                 data_expiration_ttl: _,
+                disable_wal,
                 max_total_wal_size,
+                compaction_style,
+                max_log_file_size,
+                keep_log_file_num,
             } => {
-                if max_total_wal_size.is_none() {
-                    *max_total_wal_size = Some(MAX_TOTAL_WAL_SIZE);
-                }
+                info!("Disable WAL is set to: {:?}", disable_wal);
                 info!("Max total WAL size is set to: {:?}", max_total_wal_size);
+                info!("Compaction style is set to: {:?}", compaction_style);
+                info!("Max log file size is set to: {:?}", max_log_file_size);
+                info!("Keep log file num is set to: {:?}", keep_log_file_num);
             }
         }
         if self.common.management_port <= 1024 {
@@ -64,5 +112,43 @@ impl ServiceConfiguration {
         let mut conf = Self::with_layers(&[Layer::Json(path.into())])?;
         conf.validate()?;
         Ok(conf)
+    }
+}
+
+pub mod tests {
+    use super::*;
+
+    #[test]
+    fn test_storage_config_default_values() {
+        let conf = serde_json::from_str::<Storage>(
+            r#"
+        {
+            "rocksdb": {
+                "path": "test_path",
+                "data_expiration_ttl": {
+                    "secs": 60,
+                    "nanos": 0
+                }
+            }
+        }"#,
+        )
+        .unwrap();
+
+        let Storage::RocksDB {
+            path,
+            data_expiration_ttl,
+            disable_wal,
+            max_total_wal_size,
+            compaction_style,
+            max_log_file_size,
+            keep_log_file_num,
+        } = conf;
+        assert_eq!(path, PathBuf::from("test_path"));
+        assert_eq!(data_expiration_ttl, Duration::from_secs(60));
+        assert_eq!(disable_wal, false);
+        assert_eq!(max_total_wal_size, MAX_TOTAL_WAL_SIZE);
+        assert_eq!(compaction_style, CompactionStyle::Universal);
+        assert_eq!(max_log_file_size, 0);
+        assert_eq!(keep_log_file_num, 1000);
     }
 }

--- a/services/replay/replaydb/src/service/rocksdb_service.rs
+++ b/services/replay/replaydb/src/service/rocksdb_service.rs
@@ -1,4 +1,3 @@
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
@@ -15,7 +14,7 @@ use crate::job::factory::RocksDbJobFactory;
 use crate::job::query::JobQuery;
 use crate::job::stop_condition::JobStopCondition;
 use crate::job::SyncJobStopCondition;
-use crate::service::configuration::{ServiceConfiguration, Storage};
+use crate::service::configuration::ServiceConfiguration;
 use crate::service::JobManager;
 use crate::store::rocksdb::RocksDbStore;
 use crate::store::{Store, SyncRocksDbStore};
@@ -43,14 +42,7 @@ impl TryFrom<&ServiceConfiguration> for SyncRocksDbStore {
     type Error = anyhow::Error;
 
     fn try_from(configuration: &ServiceConfiguration) -> Result<Self> {
-        let Storage::RocksDB {
-            path,
-            data_expiration_ttl,
-            max_total_wal_size,
-        } = configuration.storage.clone();
-
-        let path = PathBuf::from(path);
-        let store = RocksDbStore::new(&path, data_expiration_ttl, max_total_wal_size.unwrap())?;
+        let store = RocksDbStore::new(&configuration.storage)?;
         let sync_store = Arc::new(Mutex::new(store));
         Ok(sync_store)
     }

--- a/services/replay/replaydb/src/stream_processor.rs
+++ b/services/replay/replaydb/src/stream_processor.rs
@@ -289,6 +289,7 @@ mod tests {
     };
     use tokio::sync::Mutex;
 
+    use crate::service::configuration::{CompactionStyle, Storage};
     use crate::store::rocksdb::RocksDbStore;
     use crate::store::{gen_properly_filled_frame, Store};
     use crate::stream_processor::StreamProcessor;
@@ -297,7 +298,15 @@ mod tests {
     async fn test_stream_processor() -> Result<()> {
         let dir = tempfile::TempDir::new()?;
         let path = dir.path();
-        let db = RocksDbStore::new(path, Duration::from_secs(60), 1024 * 1024 * 1024)?;
+        let db = RocksDbStore::new(&Storage::RocksDB {
+            path: path.to_path_buf(),
+            data_expiration_ttl: Duration::from_secs(60),
+            disable_wal: false,
+            max_total_wal_size: 1024 * 1024 * 1024,
+            max_log_file_size: 0,
+            keep_log_file_num: 10,
+            compaction_style: CompactionStyle::Universal,
+        })?;
 
         let mut in_reader = NonBlockingReader::new(
             &ReaderConfig::new()

--- a/services/replay/samples/file_restreaming/replay_config.json
+++ b/services/replay/samples/file_restreaming/replay_config.json
@@ -54,7 +54,12 @@
       "data_expiration_ttl": {
         "secs": 3600,
         "nanos": 0
-      }
+      },
+      "disable_wal": false,
+      "max_total_wal_size": 1073741824,
+      "compaction_style": "universal",
+      "max_log_file_size": 0,
+      "keep_log_file_num": 1000
     }
   }
 }


### PR DESCRIPTION
This is related to the issue https://github.com/insight-platform/savant-rs/issues/206 and can be considered a continuation/extension of the recently merged https://github.com/insight-platform/savant-rs/pull/207.

The PR makes compaction style configurable (`universal` by default) and adds ability to disable WAL for writes (enabled by default), along with below rocksdb config options:
- `max_log_file_size` (defaults to 0)
- `keep_log_file_num` (defaults to 1000)

Defaults should match the expected behavior of `rocksdb` crate. 