### PR TITLE
Pin moka to 0.12.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ log = "0.4"
 
 md-5 = "0.10"
 mini-moka = "0.10"
-moka = { version = "0.12", features = ["future"] }
+moka = { version = "=0.12.10", features = ["future"] }
 
 nix = { version = "0.29", features = ["process", "signal"] }
 nom = "7"


### PR DESCRIPTION
Starting today, when compiling savant_rs from source, we started to get a build error:
<img width="1804" height="656" alt="image" src="https://github.com/user-attachments/assets/7bad8c7a-4409-49e7-91af-aded6c9052fe" />

Cargo started to lock on the new version of moka, which implements differently the trait for Cache. The new version is the https://github.com/moka-rs/moka/releases/tag/v0.12.11 released a few hours ago.

Diff: https://github.com/moka-rs/moka/compare/v0.12.10...v0.12.11

By pinning moka to the previous version, it is compiling OK again.