### PR TITLE
Define supported Python versions including free threading variants

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,8 @@ jobs:
           push: false
           load: true
           context: .
+          build-args: |
+            PYTHON_INTERPRETER=3.8 3.9 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t pypy3.10 pypy3.11
 
       - name: Copy wheels
         run: docker run --rm -v $(pwd)/distfiles:/tmp savant-rs cp -R /opt/dist /tmp


### PR DESCRIPTION
Recently @gustavovaliati mentioned we're using `savant-rs` on Python 3.13t with free threading enabled. It's working fine, but we have to build the Python package ourselves. It would be great to have it available here.

In the current build process, `maturin` is searching for all Python versions available in the Docker container ([flag here](https://github.com/insight-platform/savant-rs/blob/03ec4198bba20d95f93c5cfce9b4821440969147/utils/build.sh#L110)), but for some reason it doesn't find the versions with free threading (the ones with the `t` suffix). I've tried many settings but could not make it work. So, the best way of enabling these additional versions was to explicitly define them.

I've tested the build in isolation and with a simplified version of the GitHub workflow.
