### PR TITLE
GStreamer PTS mapping

### DIFF
--- a/services/retina_rtsp/src/gst_source.rs
+++ b/services/retina_rtsp/src/gst_source.rs
@@ -2,6 +2,7 @@ use std::collections::VecDeque;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
+use std::time::Duration;
 
 use anyhow::Context;
 use glib::prelude::*;
@@ -353,22 +354,26 @@ pub async fn run_group(
                 ntp_time,
             } => {
                 let source_id = &sources[source_idx].source_id;
-                let clock_rate = *per_source_states[source_idx].clock_rate.lock().unwrap();
-                if clock_rate == 0 {
-                    warn!("RTCP SR received before clock rate known for {}", source_id);
-                    continue;
-                }
 
                 info!(
                     "RTCP SR source_id={} rtp={} ntp=0x{:016X}",
                     source_id, rtp_time, ntp_time
                 );
 
-                // Queue SR — will be applied when a video frame's RTP >= this SR's RTP
+                // Always queue SR — clock_rate is not needed for queuing
                 sr_queues
                     .entry(source_idx)
                     .or_default()
                     .push_back((rtp_time, ntp_time));
+
+                let clock_rate = *per_source_states[source_idx].clock_rate.lock().unwrap();
+                if clock_rate == 0 {
+                    warn!(
+                        "RTCP SR queued but clock rate unknown for {}, skipping NTP sync",
+                        source_id
+                    );
+                    continue;
+                }
 
                 if let Some(ntp) = &mut ntp_sync {
                     if ntp.is_ready(source_id) && rtcp_once {
@@ -428,12 +433,33 @@ pub async fn run_group(
                     }
                 }
 
-                // Map RTP to PTS via RtpPtsMapper
+                // Fallback: when NTP sync is not configured and no RTCP SR has
+                // seeded the mapper yet, use the first keyframe's RTP timestamp
+                // as PTS base (matching the retina backend's rtp_bases approach).
+                if !rtp_mappers.contains_key(&source_idx)
+                    && ntp_sync.is_none()
+                    && is_keyframe
+                    && clock_rate > 0
+                {
+                    info!(
+                        "Source {}: seeding RTP mapper from keyframe (no RTCP SR), rtp={}",
+                        source_id, rtp_timestamp
+                    );
+                    let mapper = RtpPtsMapper::with_seed(
+                        rtp_timestamp,
+                        Duration::ZERO,
+                        (1, clock_rate as i64),
+                        (1, TIME_BASE.1),
+                    )
+                    .expect("valid timebase");
+                    rtp_mappers.insert(source_idx, mapper);
+                }
+
                 let mapper = match rtp_mappers.get_mut(&source_idx) {
                     Some(m) => m,
                     None => {
                         debug!(
-                            "No RTP mapper for {} yet (no applicable RTCP SR), skipping",
+                            "No RTP mapper for {} yet (waiting for RTCP SR or keyframe), skipping",
                             source_id
                         );
                         continue;


### PR DESCRIPTION
Adds keyframe-based PTS fallback to GStreamer backend to prevent frame drops without RTCP SRs, and ensures early RTCP SRs are queued even if clock rate is unknown.

The GStreamer backend previously required RTCP Sender Reports to seed the `RtpPtsMapper` before producing frames. If no SRs arrived (a common scenario for some cameras), all video frames were silently skipped forever, representing a significant functional regression compared to the retina backend. This fix introduces a fallback mechanism, similar to the retina backend, where the first keyframe's RTP timestamp can be used as a PTS base when NTP sync is not configured and no SRs have been received.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the RTP→PTS seeding logic for the GStreamer RTSP path, which can affect timestamp continuity and frame ordering/AV sync. However scope is localized to mapper initialization and SR handling.
> 
> **Overview**
> Prevents the GStreamer RTSP backend from permanently dropping video when RTCP Sender Reports are missing by adding a **keyframe-based fallback** to seed `RtpPtsMapper` (only when NTP sync is disabled).
> 
> Also changes RTCP SR handling to **always queue SRs** even if `clock_rate` is not known yet, and only skips the NTP-sync update until `clock_rate` becomes available; log messaging is updated to reflect the new seeding conditions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec45385ce737446d57ce0345c402c7a63047cf12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->