### PR TITLE
implemented draw disabling

### DIFF
--- a/savant_samples/src/bin/cars_demo.rs
+++ b/savant_samples/src/bin/cars_demo.rs
@@ -26,7 +26,7 @@ fn main() -> Result<()> {
 
     let resolved = cli.resolve()?;
     log::info!(
-        "cars-demo: input={} output={} gpu={} conf={} iou={} channel_cap={} fps={}/{} debug={}",
+        "cars-demo: input={} output={} gpu={} conf={} iou={} channel_cap={} fps={}/{} draw_enabled={} debug={}",
         resolved.input().display(),
         resolved.output().display(),
         resolved.gpu,
@@ -35,6 +35,7 @@ fn main() -> Result<()> {
         resolved.channel_cap,
         resolved.fps_num,
         resolved.fps_den,
+        resolved.draw_enabled,
         resolved.debug,
     );
 

--- a/savant_samples/src/cars_tracking/draw.rs
+++ b/savant_samples/src/cars_tracking/draw.rs
@@ -81,14 +81,24 @@ fn build_vehicle_object_draw(color: (i64, i64, i64)) -> anyhow::Result<ObjectDra
     ))
 }
 
-/// Build the `ObjectDrawSpec` for the cars-demo pipeline.
+/// Build the full `ObjectDrawSpec` for the cars-demo pipeline.
 ///
-/// One entry per vehicle label under namespace `DRAW_NAMESPACE`; every entry
-/// uses `BBoxSource::DetectionBox` (the detection box is always present;
-/// `track_box` is only set once a tracker match has happened and Picasso
-/// already deals correctly with the missing field).
+/// One entry per vehicle label under namespace [`DRAW_NAMESPACE`];
+/// every entry uses `BBoxSource::TrackingBox` (Picasso gracefully
+/// falls back to the detection box while a track is still being
+/// established).  A separate [`OVERLAY_NAMESPACE`] entry carries the
+/// per-frame frame-id badge.
 ///
-/// Label format: `["{label} #{track_id}", "{confidence}"]`, outside top-left.
+/// Label format:
+/// `["{label} #{track_id}", "object: #{id}", "{confidence}"]`,
+/// outside top-left.
+///
+/// To opt out of drawing entirely (no bboxes, no labels, no
+/// frame-id badge), the pipeline installs
+/// [`picasso::ObjectDrawSpec::default`] instead of calling this
+/// function and skips [`attach_frame_id_overlay`] on every frame —
+/// see the `--no-draw` CLI flag wired through
+/// [`crate::cli::ResolvedCli::draw_enabled`].
 ///
 /// Returns `Result` because the `savant_core::draw` constructors can fail on
 /// pathological input (they validate ranges); we propagate those errors as

--- a/savant_samples/src/cars_tracking/pipeline.rs
+++ b/savant_samples/src/cars_tracking/pipeline.rs
@@ -49,8 +49,8 @@ use deepstream_nvtracker::{
 };
 use parking_lot::Mutex as PlMutex;
 use picasso::prelude::{
-    Callbacks, CodecSpec, GeneralSpec, OnEncodedFrame, OutputMessage, PicassoEngine, SourceSpec,
-    TransformConfig,
+    Callbacks, CodecSpec, GeneralSpec, ObjectDrawSpec, OnEncodedFrame, OutputMessage,
+    PicassoEngine, SourceSpec, TransformConfig,
 };
 use savant_core::pipeline::stats::{StageLatencyStat, StageProcessingStat, StageStats, Stats};
 use savant_core::primitives::frame::{
@@ -179,7 +179,7 @@ pub fn run(cli: ResolvedCli) -> Result<()> {
     cuda_init(cli.gpu).map_err(|e| anyhow!("cuda init (gpu={}): {e}", cli.gpu))?;
 
     log::info!(
-        "cars-demo starting: input={} output={} gpu={} conf={} iou={} channel_cap={} fps={}/{} debug={}",
+        "cars-demo starting: input={} output={} gpu={} conf={} iou={} channel_cap={} fps={}/{} draw_enabled={} debug={}",
         cli.input.display(),
         cli.output.display(),
         cli.gpu,
@@ -188,6 +188,7 @@ pub fn run(cli: ResolvedCli) -> Result<()> {
         cli.channel_cap,
         cli.fps_num,
         cli.fps_den,
+        cli.draw_enabled,
         cli.debug
     );
 
@@ -321,8 +322,13 @@ pub fn run(cli: ResolvedCli) -> Result<()> {
         track_stage.clone(),
     )?;
 
-    let render_handle =
-        spawn_render_thread(SOURCE_ID.to_string(), picasso, rx_tracker, fatal.clone())?;
+    let render_handle = spawn_render_thread(
+        SOURCE_ID.to_string(),
+        picasso,
+        rx_tracker,
+        fatal.clone(),
+        cli.draw_enabled,
+    )?;
 
     let mux_handle = spawn_mux_thread(
         cli.output.to_string_lossy().into_owned(),
@@ -912,10 +918,11 @@ fn spawn_render_thread(
     picasso: Arc<PicassoEngine>,
     rx: TrackerResultReceiver,
     fatal: Arc<AtomicBool>,
+    draw_enabled: bool,
 ) -> Result<JoinHandle<Result<()>>> {
     thread::Builder::new()
         .name("cars-render".into())
-        .spawn(move || render_thread(source_id, picasso, rx, fatal))
+        .spawn(move || render_thread(source_id, picasso, rx, fatal, draw_enabled))
         .context("spawn render thread")
 }
 
@@ -924,16 +931,21 @@ fn render_thread(
     picasso: Arc<PicassoEngine>,
     rx: TrackerResultReceiver,
     fatal: Arc<AtomicBool>,
+    draw_enabled: bool,
 ) -> Result<()> {
-    log::info!("[render] starting source_id={source_id}");
+    log::info!("[render] starting source_id={source_id} draw_enabled={draw_enabled}");
     let mut source_spec_set = false;
     // Monotonically increasing per-frame counter rendered as the
-    // top-left `frame #N` badge.  Attaching the overlay here — after
-    // inference and tracking — keeps the synthetic object invisible to
-    // both the inference batch formation (`RoiKind::FullFrame`) and the
-    // tracker batch formation (which filters by
-    // `DETECTION_NAMESPACE`); see
-    // [`crate::cars_tracking::draw::attach_frame_id_overlay`].
+    // top-left `frame #N` badge when drawing is enabled.  Attaching
+    // the overlay here — after inference and tracking — keeps the
+    // synthetic object invisible to both the inference batch
+    // formation (`RoiKind::FullFrame`) and the tracker batch
+    // formation (which filters by `DETECTION_NAMESPACE`); see
+    // [`crate::cars_tracking::draw::attach_frame_id_overlay`].  When
+    // `draw_enabled == false` we skip the attach entirely and install
+    // an empty [`ObjectDrawSpec`] on the source spec so Picasso
+    // renders no overlays at all — decode → infer → track →
+    // transform → encode still run as normal.
     let mut frame_counter: u64 = 0;
     loop {
         match rx.recv() {
@@ -944,16 +956,23 @@ fn render_thread(
                         let w = frame.get_width().max(1) as u32;
                         let h = frame.get_height().max(1) as u32;
                         let fps = frame.get_fps();
-                        log::info!("[render] first frame: {w}x{h} fps={}/{}", fps.0, fps.1);
-                        let spec = build_source_spec(w, h, fps.0 as i32, fps.1 as i32)?;
+                        log::info!(
+                            "[render] first frame: {w}x{h} fps={}/{} draw_enabled={draw_enabled}",
+                            fps.0,
+                            fps.1,
+                        );
+                        let spec =
+                            build_source_spec(w, h, fps.0 as i32, fps.1 as i32, draw_enabled)?;
                         picasso
                             .set_source_spec(&source_id, spec)
                             .map_err(|e| anyhow!("set_source_spec: {e}"))?;
                         source_spec_set = true;
                     }
 
-                    if let Err(e) = attach_frame_id_overlay(&frame, frame_counter) {
-                        log::warn!("[render] attach_frame_id_overlay failed: {e}");
+                    if draw_enabled {
+                        if let Err(e) = attach_frame_id_overlay(&frame, frame_counter) {
+                            log::warn!("[render] attach_frame_id_overlay failed: {e}");
+                        }
                     }
                     frame_counter = frame_counter.wrapping_add(1);
 
@@ -991,9 +1010,25 @@ fn render_thread(
     Ok(())
 }
 
-fn build_source_spec(width: u32, height: u32, fps_num: i32, fps_den: i32) -> Result<SourceSpec> {
+fn build_source_spec(
+    width: u32,
+    height: u32,
+    fps_num: i32,
+    fps_den: i32,
+    draw_enabled: bool,
+) -> Result<SourceSpec> {
     let encoder = build_encoder_config(width, height, fps_num, fps_den);
-    let draw = build_vehicle_draw_spec().context("build vehicle draw spec")?;
+    // Empty [`ObjectDrawSpec`] is the `--no-draw` escape hatch:
+    // Picasso's per-object lookup returns `None` for every
+    // `(namespace, label)` pair, so no bboxes/labels/badges are
+    // composited onto the frame.  The transform + encode stages
+    // still execute so the output MP4 is a clean re-encoded copy of
+    // the source.
+    let draw = if draw_enabled {
+        build_vehicle_draw_spec().context("build vehicle draw spec")?
+    } else {
+        ObjectDrawSpec::default()
+    };
     Ok(SourceSpec {
         codec: CodecSpec::Encode {
             transform: TransformConfig::default(),
@@ -1130,6 +1165,7 @@ mod tests {
             debug: false,
             fps_num: 25,
             fps_den: 1,
+            draw_enabled: true,
         };
         let err = run(cli).unwrap_err();
         assert!(

--- a/savant_samples/src/cli.rs
+++ b/savant_samples/src/cli.rs
@@ -59,6 +59,17 @@ pub struct Cli {
     /// Output framerate denominator.  Must be >= 1.
     #[arg(long = "fps-den", default_value_t = 1)]
     pub fps_den: i32,
+
+    /// Completely disable Picasso's draw stage: no bounding boxes, no
+    /// labels, and no frame-id overlay.  The pipeline still performs
+    /// decode → infer → track → transform → encode, so the output MP4
+    /// is the re-encoded source video without any visual overlay.
+    ///
+    /// Useful for measuring raw decoder + infer + tracker + encoder
+    /// throughput (isolating the Skia draw cost) and for producing an
+    /// overlay-free reference copy of the output.
+    #[arg(long = "no-draw", default_value_t = false)]
+    pub no_draw: bool,
 }
 
 impl Cli {
@@ -140,6 +151,7 @@ impl Cli {
             debug: self.debug,
             fps_num: self.fps_num,
             fps_den: self.fps_den,
+            draw_enabled: !self.no_draw,
         })
     }
 }
@@ -166,6 +178,11 @@ pub struct ResolvedCli {
     pub fps_num: i32,
     /// Output container / encoder framerate denominator.
     pub fps_den: i32,
+    /// Whether Picasso's draw stage runs.  When `false` (CLI
+    /// `--no-draw`) no bounding boxes, labels, or frame-id overlay
+    /// are composited onto the output — decode + infer + track +
+    /// transform + encode still run as normal.
+    pub draw_enabled: bool,
 }
 
 impl ResolvedCli {
@@ -229,6 +246,36 @@ mod tests {
         .unwrap();
         let err = cli.resolve().unwrap_err();
         assert!(err.to_string().contains("--conf"));
+    }
+
+    /// `--no-draw` must default to `false` (draw stage active) and
+    /// invert to `draw_enabled = false` on the resolved struct when
+    /// the flag is set.  The toggle is the sole source of truth for
+    /// whether the render stage populates Picasso's draw spec, so a
+    /// regression here silently turns the feature off (or on) for
+    /// every user.
+    #[test]
+    fn no_draw_flag_inverts_into_draw_enabled() {
+        let cli = Cli::try_parse_from([
+            "cars-demo",
+            "--input",
+            "some.mov",
+            "--output",
+            "/tmp/out.mp4",
+        ])
+        .unwrap();
+        assert!(!cli.no_draw);
+
+        let cli = Cli::try_parse_from([
+            "cars-demo",
+            "--input",
+            "some.mov",
+            "--output",
+            "/tmp/out.mp4",
+            "--no-draw",
+        ])
+        .unwrap();
+        assert!(cli.no_draw);
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk feature toggle that only affects the render/draw configuration and logging; core decode/infer/track/encode flow is unchanged, but output visuals differ when enabled.
> 
> **Overview**
> Adds a `--no-draw` CLI flag to fully disable Picasso rendering overlays (bboxes/labels and the frame-id badge) while keeping the rest of the `cars-demo` pipeline running normally.
> 
> Threads now receive a `draw_enabled` toggle that switches the source’s draw spec to `ObjectDrawSpec::default()` and skips `attach_frame_id_overlay`; startup logs and tests were updated to cover and report this new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e9bff81dd97e21c7eba27c217fc38edac986f4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->