### PR TITLE
Implemented bitstream function which can work with encoded streams

### DIFF
--- a/savant_perception/examples/cars_demo/cars_tracking/pipeline.rs
+++ b/savant_perception/examples/cars_demo/cars_tracking/pipeline.rs
@@ -63,8 +63,9 @@ use savant_perception::shutdown::{ShutdownAction, ShutdownCause, ShutdownCtx};
 use savant_perception::supervisor::{StageKind, StageName};
 use savant_perception::templates::decoder::make_decode_frame;
 use savant_perception::templates::{
-    Decoder, DecoderResults, Function, FunctionInbox, Mp4DemuxerResults, Mp4DemuxerSource,
-    Mp4Muxer, NvInfer, NvInferResults, NvTracker, NvTrackerResults, Picasso, PicassoInbox,
+    BitstreamFunction, BitstreamFunctionInbox, Decoder, DecoderResults, Function, FunctionInbox,
+    Mp4DemuxerResults, Mp4DemuxerSource, Mp4Muxer, NvInfer, NvInferResults, NvTracker,
+    NvTrackerResults, Picasso, PicassoInbox,
 };
 use savant_perception::{Flow, HookCtx, System};
 
@@ -96,7 +97,14 @@ pub fn run(cli: ResolvedCli) -> Result<()> {
     if !cli.input.is_file() {
         bail!("input file does not exist: {}", cli.input.display());
     }
-    if cli.picasso_enabled {
+    // The `--output null` sentinel (`output_is_null = true`) keeps
+    // Picasso running but redirects the encoded bitstream into a
+    // `BitstreamFunction` terminus instead of an MP4 file, so in
+    // that mode `cli.output` is intentionally `None` and the
+    // filesystem check must be skipped.  Only require an output
+    // path when Picasso is enabled *and* the user did not opt into
+    // the null sentinel.
+    if cli.picasso_enabled && !cli.output_is_null {
         let out = cli
             .output
             .as_ref()
@@ -139,10 +147,10 @@ pub fn run(cli: ResolvedCli) -> Result<()> {
     let decoder_stage = make_stage("decoder");
     let infer_stage = make_stage("infer");
     let track_stage = make_stage("track");
-    let tail_stage_name = if cli.picasso_enabled {
-        "encode"
-    } else {
-        "function"
+    let tail_stage_name = match (cli.picasso_enabled, cli.output_is_null) {
+        (true, true) => "bitstream",
+        (true, false) => "encode",
+        (false, _) => "function",
     };
     let tail_stage = make_stage(tail_stage_name);
     core_stats.add_stage_stats(decoder_stage.clone());
@@ -494,17 +502,74 @@ pub fn run(cli: ResolvedCli) -> Result<()> {
             .build()?;
         sys.register_actor(picasso)?;
 
-        let output_path = cli
-            .output
-            .as_ref()
-            .ok_or_else(|| anyhow!("picasso enabled but output path is missing"))?
-            .to_string_lossy()
-            .into_owned();
-        let muxer = Mp4Muxer::builder(mp4_mux_name.clone(), cli.channel_cap)
-            .output(output_path)
-            .framerate(cli.fps_num, cli.fps_den)
-            .build()?;
-        sys.register_actor(muxer)?;
+        if cli.output_is_null {
+            // `--output null`: Picasso's encoder callback still
+            // produces `EncodedMsg::Frame` deliveries, but instead
+            // of muxing them into an MP4 we route them into a
+            // `BitstreamFunction` terminus that simply drops
+            // them.  The BitstreamFunction is registered under
+            // `mp4_mux_name` so picasso's already-installed
+            // default downstream peer resolves to it without any
+            // change in the picasso block above.
+            //
+            // IMPORTANT — stats accounting:
+            //
+            // In **every** picasso-enabled configuration
+            // (`--output <file>` *and* `--output null`) the
+            // canonical per-encoded-frame tick site is
+            // [`StatsEncodedSink::call`] on picasso's encoder
+            // thread: it increments the tail [`StageStats`], the
+            // core [`Stats`], and `PipelineStats.encoded_bytes`
+            // exactly once before routing the
+            // [`EncodedMsg::Frame`] onward.
+            //
+            // Because of that, the `on_frame` hook on the
+            // `BitstreamFunction` terminus **must not** tick
+            // stats — doing so would double-count every encoded
+            // frame (once on the encoder thread, once on the
+            // bitstream-terminus thread) and report 2× the real
+            // FPS / bytes.  The symptom was observed during
+            // bring-up (250 FPS instead of the ~125 FPS measured
+            // on the Mp4Muxer path).  We therefore leave
+            // `on_frame` / `on_packet` / `on_stream_info` at the
+            // default drop-on-receive no-op and only override
+            // `on_source_eos` to give the terminus the
+            // loop-exit semantics the supervisor needs.
+            let bitstream_terminus =
+                BitstreamFunction::builder(mp4_mux_name.clone(), cli.channel_cap)
+                    .inbox(
+                        BitstreamFunctionInbox::builder()
+                            // Terminus semantics: the first
+                            // `SourceEos` means the picasso
+                            // encoder has drained, so exit the
+                            // loop and let
+                            // `cars_shutdown_handler`
+                            // broadcast Shutdown to upstream
+                            // stages.
+                            .on_source_eos(|source_id, _router, ctx| {
+                                log::info!(
+                                    "[{}] SourceEos {source_id}: bitstream terminus exiting",
+                                    ctx.own_name()
+                                );
+                                Ok(Flow::Stop)
+                            })
+                            .build(),
+                    )
+                    .build();
+            sys.register_actor(bitstream_terminus)?;
+        } else {
+            let output_path = cli
+                .output
+                .as_ref()
+                .ok_or_else(|| anyhow!("picasso enabled but output path is missing"))?
+                .to_string_lossy()
+                .into_owned();
+            let muxer = Mp4Muxer::builder(mp4_mux_name.clone(), cli.channel_cap)
+                .output(output_path)
+                .framerate(cli.fps_num, cli.fps_den)
+                .build()?;
+            sys.register_actor(muxer)?;
+        }
     } else {
         let function = Function::builder(function_name.clone(), cli.channel_cap)
             .inbox(
@@ -809,6 +874,7 @@ mod tests {
             fps_den: 1,
             draw_enabled: true,
             picasso_enabled: true,
+            output_is_null: false,
         };
         let err = run(cli).unwrap_err();
         assert!(

--- a/savant_perception/examples/cars_demo/cli.rs
+++ b/savant_perception/examples/cars_demo/cli.rs
@@ -129,14 +129,44 @@ impl Cli {
     ///   its parent directory must exist.
     /// - When `--no-picasso` is set, `--output` is ignored (a warning
     ///   is logged if the user supplied one) and this returns `None`.
+    /// - The literal string `null` is a sentinel meaning "run the
+    ///   Picasso encoder but do not write an MP4" — it returns
+    ///   `None` without checking the filesystem.  Combining
+    ///   `--no-picasso --output null` is rejected as a clash: the
+    ///   two ways to disable output are not composable.
+    #[allow(dead_code)] // public symmetry with `resolved_input`
     pub fn resolved_output(&self) -> Result<Option<PathBuf>> {
+        let (output, _is_null) = self.resolve_output_mode()?;
+        Ok(output)
+    }
+
+    /// Combined output resolver returning both the path (`None`
+    /// when no file should be written) and a flag marking the
+    /// `--output null` sentinel.  Used by [`Cli::resolve`] to
+    /// populate both [`ResolvedCli::output`] and
+    /// [`ResolvedCli::output_is_null`] in a single pass.
+    fn resolve_output_mode(&self) -> Result<(Option<PathBuf>, bool)> {
+        let is_null_sentinel = self
+            .output
+            .as_deref()
+            .map(|p| p.as_os_str() == "null")
+            .unwrap_or(false);
         if self.no_picasso {
+            if is_null_sentinel {
+                bail!(
+                    "--output null cannot be combined with --no-picasso; \
+                     both disable output on their own"
+                );
+            }
             if self.output.is_some() {
                 log::warn!(
                     "--output is ignored when --no-picasso is set (no file will be written)"
                 );
             }
-            return Ok(None);
+            return Ok((None, false));
+        }
+        if is_null_sentinel {
+            return Ok((None, true));
         }
         let path = self
             .output
@@ -147,7 +177,7 @@ impl Cli {
                 bail!("output directory does not exist: {}", parent.display());
             }
         }
-        Ok(Some(path))
+        Ok((Some(path), false))
     }
 
     /// Validate all numeric knobs (channel capacity, thresholds).  Runs
@@ -175,7 +205,7 @@ impl Cli {
     pub fn resolve(&self) -> Result<ResolvedCli> {
         self.validate_knobs()?;
         let input = self.resolved_input()?;
-        let output = self.resolved_output()?;
+        let (output, output_is_null) = self.resolve_output_mode()?;
         // `--no-picasso` implies `draw_enabled = false` because the
         // draw stage lives inside Picasso; with Picasso excluded
         // there is simply nothing to draw onto.
@@ -193,6 +223,7 @@ impl Cli {
             fps_den: self.fps_den,
             draw_enabled,
             picasso_enabled,
+            output_is_null,
         })
     }
 }
@@ -232,6 +263,17 @@ pub struct ResolvedCli {
     /// still run, but no transform / overlay / encode / mux stages
     /// are spun up and no output file is produced.
     pub picasso_enabled: bool,
+    /// Set by the `--output null` sentinel: Picasso still runs
+    /// (decode + infer + track + transform + encode), but instead
+    /// of writing an MP4 the encoded bitstream is routed into a
+    /// [`BitstreamFunction`](savant_perception::templates::BitstreamFunction)
+    /// terminus that tallies packet counts and encoded byte totals.
+    ///
+    /// Only meaningful when [`Self::picasso_enabled`] is `true`;
+    /// combining it with `--no-picasso` is rejected by
+    /// [`Cli::resolve`] (the two ways to disable output are not
+    /// composable).
+    pub output_is_null: bool,
 }
 
 impl ResolvedCli {
@@ -385,5 +427,74 @@ mod tests {
         .unwrap();
         let err = cli.resolve().unwrap_err();
         assert!(err.to_string().contains("--channel-cap"));
+    }
+
+    /// `--output null` keeps Picasso enabled, suppresses the
+    /// filesystem check (the parent directory of `"null"` does
+    /// not need to exist), resolves to `output = None`, and
+    /// flips `output_is_null = true` on the resolved struct.
+    #[test]
+    fn output_null_sentinel_disables_file_but_keeps_picasso() {
+        let exe_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("examples/cars_demo/cars_tracking.rs");
+        let cli = Cli::try_parse_from([
+            "cars-demo",
+            "--input",
+            exe_dir.to_str().unwrap(),
+            "--output",
+            "null",
+        ])
+        .unwrap();
+        let resolved = cli.resolve().expect("--output null must resolve");
+        assert!(resolved.picasso_enabled);
+        assert!(resolved.output.is_none());
+        assert!(resolved.output_is_null);
+    }
+
+    /// `--no-picasso --output null` is rejected — both disable
+    /// output on their own and the resolver refuses to pick one
+    /// silently.
+    #[test]
+    fn no_picasso_rejects_output_null() {
+        let exe_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("examples/cars_demo/cars_tracking.rs");
+        let cli = Cli::try_parse_from([
+            "cars-demo",
+            "--input",
+            exe_dir.to_str().unwrap(),
+            "--no-picasso",
+            "--output",
+            "null",
+        ])
+        .unwrap();
+        let err = cli
+            .resolve()
+            .expect_err("--no-picasso + --output null must be rejected as a clash");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("--output null") && msg.contains("--no-picasso"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    /// A regular file path still produces a non-null resolved
+    /// output (so the default `output_is_null = false` path is
+    /// unaffected by the sentinel plumbing).
+    #[test]
+    fn regular_output_has_output_is_null_false() {
+        let exe_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("examples/cars_demo/cars_tracking.rs");
+        let cli = Cli::try_parse_from([
+            "cars-demo",
+            "--input",
+            exe_dir.to_str().unwrap(),
+            "--output",
+            "/tmp/out.mp4",
+        ])
+        .unwrap();
+        let resolved = cli.resolve().expect("regular output must resolve");
+        assert!(resolved.picasso_enabled);
+        assert!(!resolved.output_is_null);
+        assert!(resolved.output.is_some());
     }
 }

--- a/savant_perception/src/templates.rs
+++ b/savant_perception/src/templates.rs
@@ -27,6 +27,7 @@
 //!
 //! See [`function`] for the canonical example.
 
+pub mod bitstream_function;
 pub mod decoder;
 pub mod function;
 pub mod mp4_demuxer;
@@ -35,6 +36,12 @@ pub mod nvinfer;
 pub mod nvtracker;
 pub mod picasso;
 
+pub use bitstream_function::{
+    BitstreamFunction, BitstreamFunctionBuilder, BitstreamFunctionCommon,
+    BitstreamFunctionCommonBuilder, BitstreamFunctionInbox, BitstreamFunctionInboxBuilder,
+    OnStartedHook as BitstreamFunctionOnStartedHook,
+    OnStoppingHook as BitstreamFunctionOnStoppingHook,
+};
 pub use decoder::{
     Decoder, DecoderBuilder, DecoderCommon, DecoderCommonBuilder, DecoderInbox,
     DecoderInboxBuilder, DecoderResults, DecoderResultsBuilder,

--- a/savant_perception/src/templates/bitstream_function.rs
+++ b/savant_perception/src/templates/bitstream_function.rs
@@ -1,0 +1,800 @@
+//! [`BitstreamFunction`] — generic user-function actor for the
+//! encoded-bitstream side of the pipeline.
+//!
+//! Structurally parallel to [`Function`](super::function::Function)
+//! but consumes [`EncodedMsg`] (the envelope used by
+//! [`Mp4Muxer`](super::mp4_muxer::Mp4Muxer) and
+//! [`Decoder`](super::decoder::Decoder)) instead of
+//! [`PipelineMsg`](crate::envelopes::PipelineMsg).
+//!
+//! The template exposes one hook per data variant
+//! ([`on_stream_info`](BitstreamFunctionInboxBuilder::on_stream_info),
+//! [`on_packet`](BitstreamFunctionInboxBuilder::on_packet),
+//! [`on_frame`](BitstreamFunctionInboxBuilder::on_frame)) plus the
+//! usual
+//! [`on_source_eos`](BitstreamFunctionInboxBuilder::on_source_eos)
+//! and lifecycle hooks, and carries a
+//! [`Router<EncodedMsg>`](Router) built at factory time with an
+//! optional default peer installed via
+//! [`BitstreamFunctionBuilder::downstream`].  Hooks receive the
+//! router by shared reference so user code is the single send site
+//! — the template itself never calls `router.send`.
+//!
+//! # Grouped builder API
+//!
+//! The template exposes two hook bundles matching the cross-template
+//! grouped-builder pattern:
+//!
+//! * [`BitstreamFunctionInbox`] — inbox hooks dispatched on the
+//!   actor thread (`on_stream_info`, `on_packet`, `on_frame`,
+//!   `on_source_eos`).
+//! * [`BitstreamFunctionCommon`] — lifecycle + loop-level knobs
+//!   (`on_started`, `stopping`, `poll_timeout`).
+//!
+//! Build a bitstream function with zero user code:
+//!
+//! ```ignore
+//! use savant_perception::supervisor::{StageKind, StageName};
+//! use savant_perception::templates::BitstreamFunction;
+//!
+//! let builder = BitstreamFunction::builder(
+//!     StageName::unnamed(StageKind::Function),
+//!     16,
+//! ).build();
+//! ```
+//!
+//! The resulting actor drops every `EncodedMsg` data variant and
+//! logs `SourceEos` sentinels without terminating (pure-terminus
+//! default).  It cooperates with shutdown via the standard
+//! [`EncodedMsg::Shutdown`](crate::envelopes::EncodedMsg::Shutdown)
+//! → [`ShutdownHint::Graceful`](super::super::ShutdownHint::Graceful)
+//! path handled by the loop driver — no custom code is required.
+//!
+//! # Hooks
+//!
+//! Override per-hook for domain behaviour via the bundles:
+//!
+//! * [`BitstreamFunctionInboxBuilder::on_stream_info`] — called
+//!   with every
+//!   [`EncodedMsg::StreamInfo`](crate::envelopes::EncodedMsg::StreamInfo).
+//!   Default: drop.
+//! * [`BitstreamFunctionInboxBuilder::on_packet`] — called with
+//!   every
+//!   [`EncodedMsg::Packet`](crate::envelopes::EncodedMsg::Packet).
+//!   Default: drop.
+//! * [`BitstreamFunctionInboxBuilder::on_frame`] — called with
+//!   every
+//!   [`EncodedMsg::Frame`](crate::envelopes::EncodedMsg::Frame).
+//!   Default: drop.
+//! * [`BitstreamFunctionInboxBuilder::on_source_eos`] — called on
+//!   every
+//!   [`EncodedMsg::SourceEos`](crate::envelopes::EncodedMsg::SourceEos).
+//!   Returns [`Flow`] so the function can self-terminate on the
+//!   first EOS (e.g. single-source pipeline) or stay alive
+//!   (default).
+//! * [`BitstreamFunctionCommonBuilder::on_started`] /
+//!   [`BitstreamFunctionCommonBuilder::stopping`] — optional
+//!   lifecycle logs.  Both always installed; default is a single
+//!   `info!` log line.
+//!
+//! All hooks run on the actor's OS thread; they may capture
+//! `Send`-safe state by value and call `router.send(...)` to
+//! forward to the configured default peer, or
+//! `router.send_to(&peer, msg)` for source-id-based routing.
+//!
+//! # Runtime invariant
+//!
+//! Every hook slot on the runtime [`BitstreamFunction`] struct is
+//! a non-`Option` boxed closure.  The bundle builders'
+//! `Option<...>` fields exist purely as "was the setter called?"
+//! markers;
+//! [`BitstreamFunctionInboxBuilder::build`] and
+//! [`BitstreamFunctionCommonBuilder::build`] always substitute the
+//! matching default before the [`BitstreamFunctionBuilder`] is
+//! finalised.
+
+use std::time::Duration;
+
+use anyhow::Result;
+
+use crate::envelopes::{EncodedMsg, FramePayload, PacketPayload, StreamInfoPayload};
+use crate::router::Router;
+use crate::supervisor::StageName;
+use crate::{
+    Actor, ActorBuilder, Context, Dispatch, Flow, Handler, ShutdownPayload, SourceEosPayload,
+};
+
+/// Closure type for `on_stream_info`.  Observes every
+/// [`StreamInfoPayload`] by shared reference.  Returning `Err`
+/// aborts the loop.
+pub type StreamInfoHook = Box<
+    dyn FnMut(
+            &StreamInfoPayload,
+            &Router<EncodedMsg>,
+            &mut Context<BitstreamFunction>,
+        ) -> Result<()>
+        + Send
+        + 'static,
+>;
+
+/// Closure type for `on_packet`.  Observes every
+/// [`PacketPayload`] by shared reference.  Returning `Err` aborts
+/// the loop.
+pub type PacketHook = Box<
+    dyn FnMut(&PacketPayload, &Router<EncodedMsg>, &mut Context<BitstreamFunction>) -> Result<()>
+        + Send
+        + 'static,
+>;
+
+/// Closure type for `on_frame`.  Observes every [`FramePayload`]
+/// by shared reference.  Returning `Err` aborts the loop.
+pub type FrameHook = Box<
+    dyn FnMut(&FramePayload, &Router<EncodedMsg>, &mut Context<BitstreamFunction>) -> Result<()>
+        + Send
+        + 'static,
+>;
+
+/// Closure type for `on_source_eos`.  Returning [`Flow::Stop`]
+/// exits the receive loop on that EOS; [`Flow::Cont`] keeps the
+/// function alive.
+pub type EosHook = Box<
+    dyn FnMut(&str, &Router<EncodedMsg>, &mut Context<BitstreamFunction>) -> Result<Flow>
+        + Send
+        + 'static,
+>;
+
+/// Closure type for `on_started` — runs once when the actor's
+/// receive loop starts.  Always populated at runtime (the default
+/// is a single `info!` log line matching the legacy "no hook set"
+/// behaviour).
+pub type OnStartedHook = Box<dyn FnMut(&mut Context<BitstreamFunction>) + Send + 'static>;
+
+/// User shutdown hook invoked from [`Actor::stopping`] — the
+/// template has no load-bearing built-in cleanup, so the hook body
+/// is the only work done on stop.  Runs on the actor thread with
+/// full access to the [`Context`].  Always populated at runtime;
+/// default is a single `info!` log line.
+pub type OnStoppingHook = Box<dyn FnMut(&mut Context<BitstreamFunction>) + Send + 'static>;
+
+/// Generic user-function actor for the encoded-bitstream side of
+/// the pipeline.
+///
+/// Construct with [`BitstreamFunction::builder`].  The actor
+/// carries its hooks as boxed closures.  Every slot is non-`Option`
+/// by construction — the [`BitstreamFunctionInbox`] /
+/// [`BitstreamFunctionCommon`] bundles auto-install the matching
+/// default when the user omits a setter.
+pub struct BitstreamFunction {
+    router: Router<EncodedMsg>,
+    stream_info: StreamInfoHook,
+    packet: PacketHook,
+    frame: FrameHook,
+    source_eos: EosHook,
+    started: OnStartedHook,
+    stopping: OnStoppingHook,
+    poll_timeout: Duration,
+}
+
+impl BitstreamFunction {
+    /// Start a fluent builder for a bitstream function registered
+    /// under `name` with inbox capacity `capacity`.
+    pub fn builder(name: StageName, capacity: usize) -> BitstreamFunctionBuilder {
+        BitstreamFunctionBuilder::new(name, capacity)
+    }
+
+    /// Default `on_stream_info` hook — drops every stream-info
+    /// sentinel.
+    pub fn default_on_stream_info() -> impl FnMut(
+        &StreamInfoPayload,
+        &Router<EncodedMsg>,
+        &mut Context<BitstreamFunction>,
+    ) -> Result<()>
+           + Send
+           + 'static {
+        |_payload, _router, _ctx| Ok(())
+    }
+
+    /// Default `on_packet` hook — drops every packet.
+    pub fn default_on_packet(
+    ) -> impl FnMut(&PacketPayload, &Router<EncodedMsg>, &mut Context<BitstreamFunction>) -> Result<()>
+           + Send
+           + 'static {
+        |_payload, _router, _ctx| Ok(())
+    }
+
+    /// Default `on_frame` hook — drops every pre-built frame.
+    pub fn default_on_frame(
+    ) -> impl FnMut(&FramePayload, &Router<EncodedMsg>, &mut Context<BitstreamFunction>) -> Result<()>
+           + Send
+           + 'static {
+        |_payload, _router, _ctx| Ok(())
+    }
+
+    /// Default `on_source_eos` hook — logs at `info` level and
+    /// returns `Ok(Flow::Cont)` so the function stays alive through
+    /// an arbitrary number of per-source drainages.
+    pub fn default_on_source_eos(
+    ) -> impl FnMut(&str, &Router<EncodedMsg>, &mut Context<BitstreamFunction>) -> Result<Flow>
+           + Send
+           + 'static {
+        |source_id, _router, ctx| {
+            log::info!("[{}] SourceEos {source_id}: continuing", ctx.own_name());
+            Ok(Flow::Cont)
+        }
+    }
+
+    /// Default `on_started` hook — logs
+    /// `[{stage}] bitstream function started` at `info` level.
+    pub fn default_on_started() -> impl FnMut(&mut Context<BitstreamFunction>) + Send + 'static {
+        |ctx| {
+            log::info!("[{}] bitstream function started", ctx.own_name());
+        }
+    }
+
+    /// Default user shutdown hook — reproduces the "one info-level
+    /// log line" behaviour so omitting the bundle setter remains
+    /// equivalent to the legacy unset branch.  The template has no
+    /// load-bearing built-in cleanup, so this hook body is the
+    /// only work done on stop.
+    pub fn default_stopping() -> impl FnMut(&mut Context<BitstreamFunction>) + Send + 'static {
+        |ctx| {
+            log::info!("[{}] bitstream function stopping", ctx.own_name());
+        }
+    }
+}
+
+impl Actor for BitstreamFunction {
+    type Msg = EncodedMsg;
+
+    fn handle(&mut self, msg: EncodedMsg, ctx: &mut Context<Self>) -> Result<Flow> {
+        msg.dispatch(self, ctx)
+    }
+
+    fn poll_timeout(&self) -> Duration {
+        self.poll_timeout
+    }
+
+    fn started(&mut self, ctx: &mut Context<Self>) -> Result<()> {
+        (self.started)(ctx);
+        Ok(())
+    }
+
+    fn stopping(&mut self, ctx: &mut Context<Self>) {
+        (self.stopping)(ctx);
+    }
+}
+
+impl Handler<StreamInfoPayload> for BitstreamFunction {
+    fn handle(&mut self, msg: StreamInfoPayload, ctx: &mut Context<Self>) -> Result<Flow> {
+        (self.stream_info)(&msg, &self.router, ctx)?;
+        Ok(Flow::Cont)
+    }
+}
+
+impl Handler<PacketPayload> for BitstreamFunction {
+    fn handle(&mut self, msg: PacketPayload, ctx: &mut Context<Self>) -> Result<Flow> {
+        (self.packet)(&msg, &self.router, ctx)?;
+        Ok(Flow::Cont)
+    }
+}
+
+impl Handler<FramePayload> for BitstreamFunction {
+    fn handle(&mut self, msg: FramePayload, ctx: &mut Context<Self>) -> Result<Flow> {
+        (self.frame)(&msg, &self.router, ctx)?;
+        Ok(Flow::Cont)
+    }
+}
+
+impl Handler<SourceEosPayload> for BitstreamFunction {
+    fn handle(&mut self, msg: SourceEosPayload, ctx: &mut Context<Self>) -> Result<Flow> {
+        (self.source_eos)(&msg.source_id, &self.router, ctx)
+    }
+}
+
+/// Default no-op handler: the framework's loop driver already
+/// consumed the shutdown hint from
+/// [`EncodedMsg::Shutdown`](crate::envelopes::EncodedMsg::Shutdown)
+/// via [`Envelope::as_shutdown`](super::super::Envelope::as_shutdown),
+/// so the in-band sentinel has no remaining work to do here.
+impl Handler<ShutdownPayload> for BitstreamFunction {}
+
+/// Inbox hook bundle for [`BitstreamFunction`] — one branch per
+/// inbox message kind beyond the cooperative-shutdown sentinel.
+/// Built through [`BitstreamFunctionInbox::builder`] and handed to
+/// [`BitstreamFunctionBuilder::inbox`].  Omitted branches
+/// auto-install the matching `BitstreamFunction::default_on_*` at
+/// build time.
+pub struct BitstreamFunctionInbox {
+    stream_info: StreamInfoHook,
+    packet: PacketHook,
+    frame: FrameHook,
+    source_eos: EosHook,
+}
+
+impl BitstreamFunctionInbox {
+    /// Start a builder that auto-installs every default on
+    /// [`BitstreamFunctionInboxBuilder::build`].
+    pub fn builder() -> BitstreamFunctionInboxBuilder {
+        BitstreamFunctionInboxBuilder::new()
+    }
+}
+
+impl Default for BitstreamFunctionInbox {
+    fn default() -> Self {
+        BitstreamFunctionInboxBuilder::new().build()
+    }
+}
+
+/// Fluent builder for [`BitstreamFunctionInbox`].
+pub struct BitstreamFunctionInboxBuilder {
+    stream_info: Option<StreamInfoHook>,
+    packet: Option<PacketHook>,
+    frame: Option<FrameHook>,
+    source_eos: Option<EosHook>,
+}
+
+impl BitstreamFunctionInboxBuilder {
+    /// Empty bundle — every hook defaults to the matching
+    /// `BitstreamFunction::default_on_*` at [`build`](Self::build)
+    /// time.
+    pub fn new() -> Self {
+        Self {
+            stream_info: None,
+            packet: None,
+            frame: None,
+            source_eos: None,
+        }
+    }
+
+    /// Install a custom `on_stream_info` hook.  Fires on every
+    /// [`EncodedMsg::StreamInfo`](crate::envelopes::EncodedMsg::StreamInfo).
+    /// The hook receives the payload by shared reference along
+    /// with the stage's [`Router<EncodedMsg>`] so it can forward
+    /// via `router.send(...)` if desired.  Returning `Err` aborts
+    /// the loop and signals the supervisor via the
+    /// [`StageExitGuard`](super::super::StageExitGuard).
+    pub fn on_stream_info<F>(mut self, f: F) -> Self
+    where
+        F: FnMut(
+                &StreamInfoPayload,
+                &Router<EncodedMsg>,
+                &mut Context<BitstreamFunction>,
+            ) -> Result<()>
+            + Send
+            + 'static,
+    {
+        self.stream_info = Some(Box::new(f));
+        self
+    }
+
+    /// Install a custom `on_packet` hook.  Fires on every
+    /// [`EncodedMsg::Packet`](crate::envelopes::EncodedMsg::Packet).
+    pub fn on_packet<F>(mut self, f: F) -> Self
+    where
+        F: FnMut(
+                &PacketPayload,
+                &Router<EncodedMsg>,
+                &mut Context<BitstreamFunction>,
+            ) -> Result<()>
+            + Send
+            + 'static,
+    {
+        self.packet = Some(Box::new(f));
+        self
+    }
+
+    /// Install a custom `on_frame` hook.  Fires on every
+    /// [`EncodedMsg::Frame`](crate::envelopes::EncodedMsg::Frame).
+    pub fn on_frame<F>(mut self, f: F) -> Self
+    where
+        F: FnMut(&FramePayload, &Router<EncodedMsg>, &mut Context<BitstreamFunction>) -> Result<()>
+            + Send
+            + 'static,
+    {
+        self.frame = Some(Box::new(f));
+        self
+    }
+
+    /// Install a custom `on_source_eos` hook.  Return
+    /// [`Flow::Stop`] to self-terminate on the first EOS observed
+    /// (single-source pipelines); [`Flow::Cont`] keeps the function
+    /// alive through an arbitrary number of per-source drainages
+    /// (multiplexed pipelines).
+    pub fn on_source_eos<F>(mut self, f: F) -> Self
+    where
+        F: FnMut(&str, &Router<EncodedMsg>, &mut Context<BitstreamFunction>) -> Result<Flow>
+            + Send
+            + 'static,
+    {
+        self.source_eos = Some(Box::new(f));
+        self
+    }
+
+    /// Finalise the bundle, substituting defaults for every omitted
+    /// setter.
+    pub fn build(self) -> BitstreamFunctionInbox {
+        let BitstreamFunctionInboxBuilder {
+            stream_info,
+            packet,
+            frame,
+            source_eos,
+        } = self;
+        BitstreamFunctionInbox {
+            stream_info: stream_info
+                .unwrap_or_else(|| Box::new(BitstreamFunction::default_on_stream_info())),
+            packet: packet.unwrap_or_else(|| Box::new(BitstreamFunction::default_on_packet())),
+            frame: frame.unwrap_or_else(|| Box::new(BitstreamFunction::default_on_frame())),
+            source_eos: source_eos
+                .unwrap_or_else(|| Box::new(BitstreamFunction::default_on_source_eos())),
+        }
+    }
+}
+
+impl Default for BitstreamFunctionInboxBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Lifecycle + loop-level knob bundle for [`BitstreamFunction`].
+/// Built through [`BitstreamFunctionCommon::builder`] and handed to
+/// [`BitstreamFunctionBuilder::common`].
+pub struct BitstreamFunctionCommon {
+    started: OnStartedHook,
+    stopping: OnStoppingHook,
+    poll_timeout: Duration,
+}
+
+impl BitstreamFunctionCommon {
+    /// Start a builder seeded with defaults.
+    pub fn builder() -> BitstreamFunctionCommonBuilder {
+        BitstreamFunctionCommonBuilder::new()
+    }
+}
+
+impl Default for BitstreamFunctionCommon {
+    fn default() -> Self {
+        BitstreamFunctionCommonBuilder::new().build()
+    }
+}
+
+/// Fluent builder for [`BitstreamFunctionCommon`].
+pub struct BitstreamFunctionCommonBuilder {
+    started: Option<OnStartedHook>,
+    stopping: Option<OnStoppingHook>,
+    poll_timeout: Option<Duration>,
+}
+
+impl BitstreamFunctionCommonBuilder {
+    /// Default receive-poll cadence — matches
+    /// [`Actor::poll_timeout`](crate::Actor::poll_timeout)'s
+    /// 200 ms default.
+    pub const DEFAULT_POLL: Duration = Duration::from_millis(200);
+
+    /// Empty bundle — both hooks default to the matching
+    /// `BitstreamFunction::default_*` and `poll_timeout` defaults
+    /// to [`Self::DEFAULT_POLL`].
+    pub fn new() -> Self {
+        Self {
+            started: None,
+            stopping: None,
+            poll_timeout: None,
+        }
+    }
+
+    /// Install a custom `started` hook; the default logs
+    /// `[{stage}] bitstream function started` at `info` level.
+    pub fn on_started<F>(mut self, f: F) -> Self
+    where
+        F: FnMut(&mut Context<BitstreamFunction>) + Send + 'static,
+    {
+        self.started = Some(Box::new(f));
+        self
+    }
+
+    /// Install a custom `stopping` hook; the default
+    /// ([`BitstreamFunction::default_stopping`]) logs
+    /// `[{stage}] bitstream function stopping`.  The template has
+    /// no load-bearing built-in cleanup on [`Actor::stopping`], so
+    /// this hook's body is the **only** work done on stop.
+    pub fn stopping<F>(mut self, f: F) -> Self
+    where
+        F: FnMut(&mut Context<BitstreamFunction>) + Send + 'static,
+    {
+        self.stopping = Some(Box::new(f));
+        self
+    }
+
+    /// Override the inbox receive-poll cadence.
+    pub fn poll_timeout(mut self, d: Duration) -> Self {
+        self.poll_timeout = Some(d);
+        self
+    }
+
+    /// Finalise the bundle, substituting defaults for every omitted
+    /// setter.
+    pub fn build(self) -> BitstreamFunctionCommon {
+        let BitstreamFunctionCommonBuilder {
+            started,
+            stopping,
+            poll_timeout,
+        } = self;
+        BitstreamFunctionCommon {
+            started: started.unwrap_or_else(|| Box::new(BitstreamFunction::default_on_started())),
+            stopping: stopping.unwrap_or_else(|| Box::new(BitstreamFunction::default_stopping())),
+            poll_timeout: poll_timeout.unwrap_or(Self::DEFAULT_POLL),
+        }
+    }
+}
+
+impl Default for BitstreamFunctionCommonBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Fluent builder for [`BitstreamFunction`].
+///
+/// Every hook defaults to the "pure terminus" behaviour described
+/// in [`BitstreamFunction`]'s module docs.  Install the
+/// [`BitstreamFunctionInbox`] and [`BitstreamFunctionCommon`]
+/// bundles via [`BitstreamFunctionBuilder::inbox`] /
+/// [`BitstreamFunctionBuilder::common`] to override.  Terminate
+/// with [`BitstreamFunctionBuilder::build`] to obtain an
+/// [`ActorBuilder<BitstreamFunction>`] suitable for
+/// [`System::register_actor`](super::super::System::register_actor).
+pub struct BitstreamFunctionBuilder {
+    name: StageName,
+    capacity: usize,
+    downstream: Option<StageName>,
+    inbox: Option<BitstreamFunctionInbox>,
+    common: Option<BitstreamFunctionCommon>,
+}
+
+impl BitstreamFunctionBuilder {
+    /// Build a bitstream function under `name` with inbox capacity
+    /// `capacity` and the default hooks — drop every inbound
+    /// variant, log+continue on every EOS.
+    pub fn new(name: StageName, capacity: usize) -> Self {
+        Self {
+            name,
+            capacity,
+            downstream: None,
+            inbox: None,
+            common: None,
+        }
+    }
+
+    /// Optional default peer installed on the
+    /// [`Router<EncodedMsg>`] handed to every variant hook.  When
+    /// set, user hooks can use `router.send(msg)` to forward; when
+    /// unset, `router.send(...)` returns `false` and
+    /// `router.send_to(&peer, ...)` must be used instead for
+    /// explicit per-call routing.
+    pub fn downstream(mut self, peer: StageName) -> Self {
+        self.downstream = Some(peer);
+        self
+    }
+
+    /// Install a [`BitstreamFunctionInbox`] bundle — inbox hook
+    /// slots (`on_stream_info`, `on_packet`, `on_frame`,
+    /// `on_source_eos`).  Omitting this call is equivalent to
+    /// `.inbox(BitstreamFunctionInbox::default())`, which wires
+    /// every slot to the matching
+    /// `BitstreamFunction::default_on_*`.
+    pub fn inbox(mut self, i: BitstreamFunctionInbox) -> Self {
+        self.inbox = Some(i);
+        self
+    }
+
+    /// Install a [`BitstreamFunctionCommon`] bundle — lifecycle
+    /// and loop-level knobs (`on_started`, `stopping`,
+    /// `poll_timeout`).  Omitting this call is equivalent to
+    /// `.common(BitstreamFunctionCommon::default())`.
+    pub fn common(mut self, c: BitstreamFunctionCommon) -> Self {
+        self.common = Some(c);
+        self
+    }
+
+    /// Finalise the template configuration and obtain the
+    /// Layer-A [`ActorBuilder<BitstreamFunction>`] ready for
+    /// [`System::register_actor`](super::super::System::register_actor).
+    pub fn build(self) -> ActorBuilder<BitstreamFunction> {
+        let Self {
+            name,
+            capacity,
+            downstream,
+            inbox,
+            common,
+        } = self;
+        let BitstreamFunctionInbox {
+            stream_info,
+            packet,
+            frame,
+            source_eos,
+        } = inbox.unwrap_or_default();
+        let BitstreamFunctionCommon {
+            started,
+            stopping,
+            poll_timeout,
+        } = common.unwrap_or_default();
+        // Hooks are owned by the actor and must be moved into the
+        // factory closure.  We wrap the config into an Option so
+        // the `FnOnce`-style take-once move is obvious to the
+        // reader and to the borrow checker (the factory closure
+        // here is called once per registration).
+        let mut slots = Some((stream_info, packet, frame, source_eos, started, stopping));
+        ActorBuilder::new(name, capacity)
+            .poll_timeout(poll_timeout)
+            .factory(move |bx| {
+                let router: Router<EncodedMsg> = bx.router(downstream.as_ref())?;
+                let (stream_info, packet, frame, source_eos, started, stopping) = slots
+                    .take()
+                    .expect("BitstreamFunction factory invoked more than once");
+                Ok(BitstreamFunction {
+                    router,
+                    stream_info,
+                    packet,
+                    frame,
+                    source_eos,
+                    started,
+                    stopping,
+                    poll_timeout,
+                })
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::supervisor::{StageKind, StageName};
+    use crate::{ShutdownAction, ShutdownCause, ShutdownCtx, System};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    /// The default bitstream function stops when the supervisor
+    /// signals shutdown (via `sys.run`'s in-band broadcast
+    /// triggered by the absence of any other stage returning an
+    /// exit trigger).
+    #[test]
+    fn default_bitstream_function_runs_and_stops_on_broadcast() {
+        let mut sys = System::new()
+            .install_ctrlc_handler(false)
+            .quiescence(Duration::from_millis(0))
+            .on_shutdown(|_cause: ShutdownCause, _ctx: &mut ShutdownCtx<'_>| {
+                Ok(ShutdownAction::Broadcast {
+                    grace: None,
+                    reason: std::borrow::Cow::Borrowed("test"),
+                })
+            });
+        let addr = sys
+            .register_actor(
+                BitstreamFunction::builder(StageName::unnamed(StageKind::Function), 4).build(),
+            )
+            .unwrap();
+
+        addr.send(EncodedMsg::SourceEos {
+            source_id: "s1".into(),
+        })
+        .unwrap();
+
+        addr.send(EncodedMsg::Shutdown {
+            grace: None,
+            reason: std::borrow::Cow::Borrowed("done"),
+        })
+        .unwrap();
+
+        let report = sys.run().unwrap();
+        assert!(report.stage_results[0].1.is_ok());
+    }
+
+    /// Custom `on_source_eos` can self-terminate on the first EOS.
+    #[test]
+    fn custom_source_eos_stops_function() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let counter_clone = counter.clone();
+        let mut sys = System::new()
+            .install_ctrlc_handler(false)
+            .quiescence(Duration::from_millis(0));
+        let addr = sys
+            .register_actor(
+                BitstreamFunction::builder(StageName::unnamed(StageKind::Function), 4)
+                    .inbox(
+                        BitstreamFunctionInbox::builder()
+                            .on_source_eos(move |sid, _router, _ctx| {
+                                counter_clone.fetch_add(1, Ordering::Relaxed);
+                                let _ = sid;
+                                Ok(Flow::Stop)
+                            })
+                            .build(),
+                    )
+                    .build(),
+            )
+            .unwrap();
+
+        addr.send(EncodedMsg::SourceEos {
+            source_id: "s1".into(),
+        })
+        .unwrap();
+
+        let report = sys.run().unwrap();
+        assert_eq!(counter.load(Ordering::Relaxed), 1);
+        assert!(report.stage_results[0].1.is_ok());
+    }
+
+    /// Compile-only verification: a full-hook builder (inbox +
+    /// common) is accepted and every default forwarder slots into
+    /// the matching generic bound.
+    #[test]
+    fn custom_hooks_are_installed() {
+        let _ = BitstreamFunction::builder(StageName::unnamed(StageKind::Function), 2)
+            .downstream(StageName::unnamed(StageKind::Mp4Mux))
+            .inbox(
+                BitstreamFunctionInbox::builder()
+                    .on_stream_info(|_pl, _router, _ctx| Ok(()))
+                    .on_packet(|_pl, _router, _ctx| Ok(()))
+                    .on_frame(|_pl, _router, _ctx| Ok(()))
+                    .on_source_eos(|_sid, _router, _ctx| Ok(Flow::Cont))
+                    .build(),
+            )
+            .common(
+                BitstreamFunctionCommon::builder()
+                    .on_started(|ctx| log::debug!("started {}", ctx.own_name()))
+                    .stopping(|ctx| log::debug!("stopping {}", ctx.own_name()))
+                    .poll_timeout(Duration::from_millis(50))
+                    .build(),
+            )
+            .build();
+    }
+
+    /// Confirms that each `default_on_*` associated function slots
+    /// into the bundle builders' generic hook bounds as-is.
+    #[test]
+    fn default_forwarders_compile() {
+        let _ = BitstreamFunction::builder(StageName::unnamed(StageKind::Function), 2)
+            .inbox(
+                BitstreamFunctionInbox::builder()
+                    .on_stream_info(BitstreamFunction::default_on_stream_info())
+                    .on_packet(BitstreamFunction::default_on_packet())
+                    .on_frame(BitstreamFunction::default_on_frame())
+                    .on_source_eos(BitstreamFunction::default_on_source_eos())
+                    .build(),
+            )
+            .common(
+                BitstreamFunctionCommon::builder()
+                    .on_started(BitstreamFunction::default_on_started())
+                    .stopping(BitstreamFunction::default_stopping())
+                    .build(),
+            )
+            .build();
+    }
+
+    /// Every slot on the runtime [`BitstreamFunction`] struct is
+    /// non-`Option` — the bundle builders always substitute a
+    /// default.  Compile-only check via a destructuring pattern
+    /// that refuses any `Option<_>` wrapper.
+    #[test]
+    fn runtime_invariant_all_hooks_populated() {
+        use crate::context::BuildCtx;
+        use crate::registry::Registry;
+        use crate::shared::SharedStore;
+        let sb = BitstreamFunction::builder(StageName::unnamed(StageKind::Function), 2).build();
+        let parts = sb.into_parts();
+        let reg = Arc::new(Registry::new());
+        let shared = Arc::new(SharedStore::new());
+        let stop_flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let bx = BuildCtx::new(&parts.name, &reg, &shared, &stop_flag);
+        let func = (parts.factory)(&bx).expect("factory resolves");
+        let BitstreamFunction {
+            router: _,
+            stream_info: _,
+            packet: _,
+            frame: _,
+            source_eos: _,
+            started: _,
+            stopping: _,
+            poll_timeout: _,
+        } = func;
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new actor template and changes cars-demo output routing/CLI semantics, which could affect pipeline termination and encoded-frame accounting if misconfigured.
> 
> **Overview**
> Adds a new `templates::BitstreamFunction` actor template (parallel to `Function`) that consumes `EncodedMsg` and exposes grouped hook builders for stream-info/packet/frame/EOS plus lifecycle hooks.
> 
> Updates the `cars-demo` CLI and pipeline to support an `--output null` sentinel: Picasso still runs, but encoded output is routed to a drop terminus (`BitstreamFunction`) instead of `Mp4Muxer`, with updated tail-stage naming and tests covering the new flag interactions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2af6ac69215f36492dfc029d949f6d53d5068162. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->