### PR TITLE
added urisource demuxer based on urisourcebin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,7 @@ core-tests:
 # aborts the rest and fails the make target. GPU-heavy runs may need, e.g.:
 #   env -u DISPLAY EGL_PLATFORM=device make deepstream-tests
 DEEPSTREAM_TEST_CRATES := \
+	savant-gstreamer \
 	savant-deepstream-buffers \
 	savant-deepstream-decoders \
 	savant-deepstream-encoders \
@@ -127,10 +128,11 @@ DEEPSTREAM_TEST_CRATES := \
 	savant-nvidia-gpu-utils \
 	savant-deepstream-nvinfer \
 	savant-deepstream-nvtracker \
-	savant-picasso
+	savant-picasso \
+	savant-perception-framework
 
 deepstream-tests:
-	@echo "Running savant_deepstream crate tests (one package per cargo invocation)..."
+	@echo "Running savant-deepstream crate tests (one package per cargo invocation)..."
 	@set -e; cd $(PROJECT_DIR); \
 	for p in $(DEEPSTREAM_TEST_CRATES); do \
 		echo "==> cargo test -p $$p"; \

--- a/savant_core/savant_core/src/utils/release_seal.rs
+++ b/savant_core/savant_core/src/utils/release_seal.rs
@@ -4,12 +4,26 @@
 //! [`ReleaseSeal::release`] (e.g. on drop) and consumers that block on
 //! [`ReleaseSeal::wait`] or poll [`ReleaseSeal::is_released`].
 
+use std::sync::atomic::{AtomicU64, Ordering};
+
 use parking_lot::{Condvar, Mutex};
+
+/// Process-local monotonic counter used to mint a unique [`ReleaseSeal::id`]
+/// for every seal instance. `Relaxed` ordering is sufficient: the counter is
+/// only used to obtain distinct IDs, and the resulting `id` field is published
+/// to other threads via `Arc`'s own acquire/release semantics, not via this
+/// counter.
+static SEAL_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Condvar-gated flag flipped once by [`Self::release`].
 ///
+/// Each instance carries a process-local unique [`Self::id`] used by upstream
+/// log lines (e.g. `Sealed<T>::unseal` emits a periodic `warn!` keyed by this
+/// id when the producer fails to release in a timely manner).
+///
 /// Thread-safe; safe to share via [`std::sync::Arc`].
 pub struct ReleaseSeal {
+    id: u64,
     released: Mutex<bool>,
     condvar: Condvar,
 }
@@ -17,6 +31,7 @@ pub struct ReleaseSeal {
 impl std::fmt::Debug for ReleaseSeal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ReleaseSeal")
+            .field("id", &self.id)
             .field("released", &*self.released.lock())
             .finish()
     }
@@ -24,11 +39,29 @@ impl std::fmt::Debug for ReleaseSeal {
 
 impl ReleaseSeal {
     /// Creates a seal in the non-released state.
+    ///
+    /// A process-local unique [`Self::id`] is assigned and emitted on
+    /// `log::trace!` so that downstream `warn!` lines (see
+    /// `deepstream_buffers::sealed::Sealed::unseal`) can be correlated back
+    /// to the originating producer.
     pub fn new() -> Self {
+        let id = SEAL_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+        log::trace!("ReleaseSeal[{}] created", id);
         Self {
+            id,
             released: Mutex::new(false),
             condvar: Condvar::new(),
         }
+    }
+
+    /// Returns the process-local unique identifier of this seal.
+    ///
+    /// IDs are assigned monotonically by [`Self::new`] from a global atomic
+    /// counter; they are stable for the lifetime of the seal and unaffected
+    /// by [`Self::release`].
+    #[inline]
+    pub fn id(&self) -> u64 {
+        self.id
     }
 
     /// Marks the seal as released and wakes all waiters.
@@ -124,5 +157,62 @@ mod tests {
         let seal = ReleaseSeal::new();
         assert!(!seal.wait_timeout(Duration::from_millis(30)));
         assert!(!seal.is_released());
+    }
+
+    #[test]
+    fn id_is_unique_and_monotonic() {
+        // Allocate a batch of seals from a single thread and assert that
+        // every id is distinct and strictly increasing. This is the
+        // single-thread guarantee provided by `fetch_add` on the same
+        // atomic, regardless of `Ordering::Relaxed`.
+        const N: usize = 64;
+        let ids: Vec<u64> = (0..N).map(|_| ReleaseSeal::new().id()).collect();
+        for pair in ids.windows(2) {
+            assert!(
+                pair[1] > pair[0],
+                "ids must be strictly increasing: {:?}",
+                pair
+            );
+        }
+        let unique: std::collections::HashSet<u64> = ids.iter().copied().collect();
+        assert_eq!(unique.len(), N, "ids must all be unique");
+    }
+
+    #[test]
+    fn id_accessible_after_release() {
+        let seal = ReleaseSeal::new();
+        let id_before = seal.id();
+        seal.release();
+        assert_eq!(seal.id(), id_before);
+        assert!(seal.is_released());
+    }
+
+    #[test]
+    fn ids_unique_across_threads() {
+        // Concurrent allocation from multiple threads still yields a total
+        // ordering on the atomic counter, so every id is unique even though
+        // we use `Ordering::Relaxed` (atomicity of the read-modify-write is
+        // independent of the chosen memory ordering).
+        const THREADS: usize = 8;
+        const PER_THREAD: usize = 64;
+        let handles: Vec<_> = (0..THREADS)
+            .map(|_| {
+                thread::spawn(|| {
+                    (0..PER_THREAD)
+                        .map(|_| ReleaseSeal::new().id())
+                        .collect::<Vec<u64>>()
+                })
+            })
+            .collect();
+        let mut all_ids = Vec::with_capacity(THREADS * PER_THREAD);
+        for h in handles {
+            all_ids.extend(h.join().unwrap());
+        }
+        let unique: std::collections::HashSet<u64> = all_ids.iter().copied().collect();
+        assert_eq!(
+            unique.len(),
+            all_ids.len(),
+            "ids must be globally unique across threads"
+        );
     }
 }

--- a/savant_core/savant_core_py/src/deepstream/inputs.rs
+++ b/savant_core/savant_core_py/src/deepstream/inputs.rs
@@ -216,6 +216,10 @@ impl PySkipReason {
     fn is_decoder_creation_failed(&self) -> bool {
         matches!(self.0, SkipReason::DecoderCreationFailed(_))
     }
+    #[getter]
+    fn is_decoder_restarted(&self) -> bool {
+        matches!(self.0, SkipReason::DecoderRestarted(_))
+    }
 
     /// Human-readable detail for string-carrying variants, or ``None``.
     #[getter]
@@ -227,6 +231,7 @@ impl PySkipReason {
             SkipReason::UnsupportedCodec(c) => Some(c.as_deref().unwrap_or("(none)").to_string()),
             SkipReason::InvalidPayload(msg) => Some(msg.clone()),
             SkipReason::DecoderCreationFailed(msg) => Some(msg.clone()),
+            SkipReason::DecoderRestarted(msg) => Some(msg.clone()),
             _ => None,
         }
     }
@@ -618,6 +623,45 @@ impl PyErrorOutput {
     }
 }
 
+/// Aggregate signal emitted when the FlexibleDecoder transparently restarted
+/// after the underlying NvDecoder worker died (e.g. a watchdog trip).
+#[pyclass(name = "RestartedOutput", module = "savant_rs.deepstream")]
+pub struct PyRestartedOutput {
+    source_id: String,
+    reason: String,
+    lost_frames: usize,
+}
+
+#[pymethods]
+impl PyRestartedOutput {
+    /// Source id of the FlexibleDecoder that restarted.
+    #[getter]
+    fn source_id(&self) -> &str {
+        &self.source_id
+    }
+
+    /// Human-readable reason for the restart.
+    #[getter]
+    fn reason(&self) -> &str {
+        &self.reason
+    }
+
+    /// Number of in-flight frames lost because of the restart.  Each is
+    /// also surfaced separately as a ``Skipped`` output with reason
+    /// ``DecoderRestarted``.
+    #[getter]
+    fn lost_frames(&self) -> usize {
+        self.lost_frames
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "RestartedOutput(source_id={:?}, reason={:?}, lost_frames={})",
+            self.source_id, self.reason, self.lost_frames
+        )
+    }
+}
+
 // ─── FlexibleDecoderOutput (container) ──────────────────────────────────
 
 enum OutputVariant {
@@ -628,6 +672,7 @@ enum OutputVariant {
     SourceEos(Py<PySourceEosOutput>),
     Event(Py<PyEventOutput>),
     Error(Py<PyErrorOutput>),
+    Restarted(Py<PyRestartedOutput>),
 }
 
 /// Callback payload from :class:`FlexibleDecoder`.
@@ -682,6 +727,18 @@ impl PyFlexibleDecoderOutput {
                 FlexibleDecoderOutput::Error(ref e) => {
                     OutputVariant::Error(Py::new(py, PyErrorOutput(e.to_string()))?)
                 }
+                FlexibleDecoderOutput::Restarted {
+                    ref source_id,
+                    ref reason,
+                    lost_frames,
+                } => OutputVariant::Restarted(Py::new(
+                    py,
+                    PyRestartedOutput {
+                        source_id: source_id.clone(),
+                        reason: reason.clone(),
+                        lost_frames,
+                    },
+                )?),
             }
         };
         Ok(Self(variant))
@@ -719,6 +776,10 @@ impl PyFlexibleDecoderOutput {
     #[getter]
     fn is_error(&self) -> bool {
         matches!(self.0, OutputVariant::Error(_))
+    }
+    #[getter]
+    fn is_restarted(&self) -> bool {
+        matches!(self.0, OutputVariant::Restarted(_))
     }
 
     // ── typed downcast methods ──
@@ -779,6 +840,14 @@ impl PyFlexibleDecoderOutput {
         }
     }
 
+    /// Downcast to :class:`RestartedOutput`, or ``None``.
+    fn as_restarted(&self, py: Python<'_>) -> Option<Py<PyRestartedOutput>> {
+        match &self.0 {
+            OutputVariant::Restarted(v) => Some(v.clone_ref(py)),
+            _ => None,
+        }
+    }
+
     fn __repr__(&self) -> String {
         match &self.0 {
             OutputVariant::Frame(_) => "FlexibleDecoderOutput(Frame)".to_string(),
@@ -790,6 +859,7 @@ impl PyFlexibleDecoderOutput {
             OutputVariant::SourceEos(_) => "FlexibleDecoderOutput(SourceEos)".to_string(),
             OutputVariant::Event(_) => "FlexibleDecoderOutput(Event)".to_string(),
             OutputVariant::Error(_) => "FlexibleDecoderOutput(Error)".to_string(),
+            OutputVariant::Restarted(_) => "FlexibleDecoderOutput(Restarted)".to_string(),
         }
     }
 }
@@ -1249,6 +1319,7 @@ pub fn register_inputs_classes(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PySourceEosOutput>()?;
     m.add_class::<PyEventOutput>()?;
     m.add_class::<PyErrorOutput>()?;
+    m.add_class::<PyRestartedOutput>()?;
     m.add_class::<PyFlexibleDecoderOutput>()?;
     m.add_class::<PyFlexibleDecoder>()?;
     m.add_class::<PyEvictionDecision>()?;

--- a/savant_core/savant_core_py/src/gstreamer.rs
+++ b/savant_core/savant_core_py/src/gstreamer.rs
@@ -11,11 +11,15 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use pyo3::prelude::*;
+use pyo3::types::{PyBytes, PyDict};
 use savant_core::primitives::video_codec::VideoCodec;
 use savant_gstreamer::mp4_demuxer::{
     DemuxedPacket, Mp4Demuxer, Mp4DemuxerError, Mp4DemuxerOutput, VideoInfo,
 };
 use savant_gstreamer::mp4_muxer::{Mp4Muxer, Mp4MuxerError};
+use savant_gstreamer::uri_demuxer::{
+    PropertyValue, UriDemuxer, UriDemuxerConfig, UriDemuxerError, UriDemuxerOutput,
+};
 
 use crate::primitives::frame::PyVideoCodec;
 
@@ -25,6 +29,54 @@ fn muxer_err(e: Mp4MuxerError) -> PyErr {
 
 fn demuxer_err(e: Mp4DemuxerError) -> PyErr {
     pyo3::exceptions::PyRuntimeError::new_err(e.to_string())
+}
+
+fn uri_demuxer_err(e: UriDemuxerError) -> PyErr {
+    pyo3::exceptions::PyRuntimeError::new_err(e.to_string())
+}
+
+/// Coerce a Python dict of `{str: scalar}` to a `Vec<(String, PropertyValue)>`.
+///
+/// Accepts `bool`, `int`, `float`, `str`, and `bytes` values. Any other type
+/// raises :class:`TypeError` naming the offending key.
+fn pydict_to_props(dict: &Bound<'_, PyDict>) -> PyResult<Vec<(String, PropertyValue)>> {
+    let mut out = Vec::with_capacity(dict.len());
+    for (key, value) in dict.iter() {
+        let k: String = key.extract().map_err(|_| {
+            let tname = key
+                .get_type()
+                .name()
+                .map(|n| n.to_string())
+                .unwrap_or_else(|_| "<?>".to_string());
+            pyo3::exceptions::PyTypeError::new_err(format!("property key must be str, got {tname}"))
+        })?;
+        // Order matters: `bool` must be checked before `i64` because `True`/`False`
+        // extract as both. Likewise `i64` before `u64`/`f64` to preserve signedness.
+        let pv = if value.is_instance_of::<pyo3::types::PyBool>() {
+            PropertyValue::Bool(value.extract::<bool>()?)
+        } else if let Ok(i) = value.extract::<i64>() {
+            PropertyValue::I64(i)
+        } else if let Ok(u) = value.extract::<u64>() {
+            PropertyValue::U64(u)
+        } else if let Ok(f) = value.extract::<f64>() {
+            PropertyValue::F64(f)
+        } else if let Ok(s) = value.extract::<String>() {
+            PropertyValue::String(s)
+        } else if let Ok(bytes) = value.cast::<PyBytes>() {
+            PropertyValue::Bytes(bytes.as_bytes().to_vec())
+        } else {
+            let tname = value
+                .get_type()
+                .name()
+                .map(|n| n.to_string())
+                .unwrap_or_else(|_| "<?>".to_string());
+            return Err(pyo3::exceptions::PyTypeError::new_err(format!(
+                "property '{k}' has unsupported value type '{tname}': expected bool, int, float, str, or bytes"
+            )));
+        };
+        out.push((k, pv));
+    }
+    Ok(out)
 }
 
 /// Extract a [`VideoCodec`] from a Python object.
@@ -297,6 +349,22 @@ impl PyMp4DemuxerOutput {
         };
         Ok(Self(variant))
     }
+
+    /// Build from a [`UriDemuxerOutput`]. The Python-side class is shared
+    /// across both demuxers so user callbacks have a single signature.
+    fn from_uri_rust(py: Python<'_>, output: UriDemuxerOutput) -> PyResult<Self> {
+        let variant = match output {
+            UriDemuxerOutput::StreamInfo(info) => {
+                DemuxerOutputVariant::StreamInfo(Py::new(py, PyVideoInfo { inner: info })?)
+            }
+            UriDemuxerOutput::Packet(pkt) => {
+                DemuxerOutputVariant::Packet(Py::new(py, PyDemuxedPacket { inner: pkt })?)
+            }
+            UriDemuxerOutput::Eos => DemuxerOutputVariant::Eos,
+            UriDemuxerOutput::Error(e) => DemuxerOutputVariant::Error(e.to_string()),
+        };
+        Ok(Self(variant))
+    }
 }
 
 #[pymethods]
@@ -548,6 +616,223 @@ impl Drop for PyMp4Demuxer {
     }
 }
 
+// ---------------------------------------------------------------------------
+// UriDemuxer
+// ---------------------------------------------------------------------------
+
+/// Callback-based GStreamer URI demuxer:
+/// ``urisourcebin -> parsebin -> [byte-stream capsfilter] -> queue -> appsink``.
+///
+/// Reads encoded elementary video packets from any GStreamer-supported URI
+/// (``file://``, ``http(s)://``, ``rtsp://``, ``hls://``, ``mpegts://``, ...)
+/// without decoding, and delivers them through ``result_callback``.
+///
+/// The callback receives :class:`Mp4DemuxerOutput` instances (shared with
+/// :class:`Mp4Demuxer`); the variants (StreamInfo / Packet / Eos / Error)
+/// behave identically.
+///
+/// When ``parsed=True`` (the default), codec-specific parsers downstream of
+/// ``parsebin`` emit byte-stream (Annex-B) H.264/HEVC; otherwise the
+/// parsebin-native format passes through.
+///
+/// **Threading**: the callback fires on GStreamer's internal streaming
+/// thread.  Do **not** call :meth:`finish` from within the callback.
+///
+/// Args:
+///     uri (str): Source URI (non-empty).
+///     result_callback: ``Callable[[Mp4DemuxerOutput], None]`` invoked for
+///         every stream-info, packet, EOS, or error event.
+///     parsed (bool): If ``True``, request byte-stream output for H.264/HEVC.
+///         Defaults to ``True``.
+///     bin_properties (dict | None): Properties applied to the
+///         ``urisourcebin`` element (e.g. ``{"buffer-size": 8_388_608}``).
+///         Values must be ``bool``, ``int``, ``float``, ``str``, or ``bytes``.
+///     source_properties (dict | None): Properties applied to the inner
+///         source element autoplugged by ``urisourcebin`` (e.g. ``rtspsrc``,
+///         ``souphttpsrc``) via the ``source-setup`` signal. Same accepted
+///         value types as ``bin_properties``. Failures on individual
+///         properties surface as :class:`Mp4DemuxerOutput` error events to
+///         the callback (they do **not** tear down the pipeline up front).
+///
+/// Raises:
+///     RuntimeError: Pipeline construction failed, URI is missing/malformed,
+///         or a *bin* property cannot be applied.
+///     TypeError: A ``bin_properties`` / ``source_properties`` value has an
+///         unsupported type.
+///
+/// Example::
+///
+///     from pathlib import Path
+///     from savant_rs.gstreamer import UriDemuxer
+///
+///     packets = []
+///     def on_output(out):
+///         if out.is_packet:
+///             packets.append(out.as_packet())
+///
+///     demuxer = UriDemuxer(Path("/data/clip.mp4").as_uri(), on_output)
+///     demuxer.wait()
+///     for pkt in packets:
+///         print(pkt.pts_ns, len(pkt.data))
+#[pyclass(name = "UriDemuxer", module = "savant_rs.gstreamer")]
+pub struct PyUriDemuxer {
+    inner: Option<UriDemuxer>,
+}
+
+#[pymethods]
+impl PyUriDemuxer {
+    #[new]
+    #[pyo3(signature = (uri, result_callback, parsed = true, bin_properties = None, source_properties = None))]
+    fn new(
+        py: Python<'_>,
+        uri: &str,
+        result_callback: Py<PyAny>,
+        parsed: bool,
+        bin_properties: Option<Bound<'_, PyDict>>,
+        source_properties: Option<Bound<'_, PyDict>>,
+    ) -> PyResult<Self> {
+        let bin_props = match bin_properties {
+            Some(d) => pydict_to_props(&d)?,
+            None => Vec::new(),
+        };
+        let src_props = match source_properties {
+            Some(d) => pydict_to_props(&d)?,
+            None => Vec::new(),
+        };
+
+        let mut cfg = UriDemuxerConfig::new(uri).with_parsed(parsed);
+        cfg.bin_properties = bin_props;
+        cfg.source_properties = src_props;
+
+        let on_output: Arc<dyn Fn(UriDemuxerOutput) + Send + Sync> =
+            Arc::new(move |output: UriDemuxerOutput| {
+                Python::attach(|py| {
+                    let py_output = match PyMp4DemuxerOutput::from_uri_rust(py, output) {
+                        Ok(o) => o,
+                        Err(e) => {
+                            log::error!("UriDemuxer: failed to wrap output: {e}");
+                            return;
+                        }
+                    };
+                    if let Err(e) = result_callback.call1(py, (py_output,)) {
+                        log::error!("UriDemuxer result_callback error: {e}");
+                    }
+                });
+            });
+
+        let demuxer = py.detach(move || {
+            UriDemuxer::new(cfg, move |out| on_output(out)).map_err(uri_demuxer_err)
+        })?;
+
+        Ok(Self {
+            inner: Some(demuxer),
+        })
+    }
+
+    /// Block until the demuxer reaches EOS, encounters an error, or
+    /// :meth:`finish` is called.
+    ///
+    /// The GIL is released while waiting so the callback can fire.
+    fn wait(&self, py: Python<'_>) -> PyResult<()> {
+        if let Some(ref inner) = self.inner {
+            py.detach(|| inner.wait());
+        }
+        Ok(())
+    }
+
+    /// Block until the demuxer finishes or the timeout expires.
+    ///
+    /// Args:
+    ///     timeout_ms (int): Timeout in milliseconds.
+    ///
+    /// Returns:
+    ///     bool: ``True`` if finished, ``False`` on timeout.
+    fn wait_timeout(&self, py: Python<'_>, timeout_ms: u64) -> PyResult<bool> {
+        if let Some(ref inner) = self.inner {
+            let timeout = Duration::from_millis(timeout_ms);
+            Ok(py.detach(|| inner.wait_timeout(timeout)))
+        } else {
+            Ok(true)
+        }
+    }
+
+    /// Auto-detected video codec from the stream, or ``None``.
+    #[getter]
+    fn detected_codec(&self) -> Option<PyVideoCodec> {
+        self.inner
+            .as_ref()
+            .and_then(|d| d.detected_codec())
+            .map(|c| c.into())
+    }
+
+    /// Auto-detected video-stream metadata, or ``None`` if caps have not been
+    /// observed yet.
+    #[getter]
+    fn video_info(&self, py: Python<'_>) -> PyResult<Option<Py<PyVideoInfo>>> {
+        self.inner
+            .as_ref()
+            .and_then(|d| d.video_info())
+            .map(|inner| Py::new(py, PyVideoInfo { inner }))
+            .transpose()
+    }
+
+    /// Block until :class:`VideoInfo` is known, the pipeline terminates, or
+    /// the timeout expires.
+    ///
+    /// Args:
+    ///     timeout_ms (int): Timeout in milliseconds.
+    ///
+    /// Returns:
+    ///     Optional[VideoInfo]: ``None`` on timeout or if the pipeline ended
+    ///     before caps were observed.
+    ///
+    /// The GIL is released while waiting.
+    fn wait_for_video_info(
+        &self,
+        py: Python<'_>,
+        timeout_ms: u64,
+    ) -> PyResult<Option<Py<PyVideoInfo>>> {
+        let Some(ref inner) = self.inner else {
+            return Ok(None);
+        };
+        let timeout = Duration::from_millis(timeout_ms);
+        let info = py.detach(|| inner.wait_for_video_info(timeout));
+        info.map(|inner| Py::new(py, PyVideoInfo { inner }))
+            .transpose()
+    }
+
+    /// Shut down the demuxer pipeline.
+    ///
+    /// Safe to call multiple times. After this call, no more callbacks
+    /// will fire.
+    ///
+    /// Must **not** be called from within the ``result_callback``.
+    fn finish(&mut self, py: Python<'_>) {
+        if let Some(mut inner) = self.inner.take() {
+            py.detach(move || inner.finish());
+        }
+    }
+
+    /// Whether the demuxer has been finalized.
+    #[getter]
+    fn is_finished(&self) -> bool {
+        self.inner.as_ref().map(|d| d.is_finished()).unwrap_or(true)
+    }
+}
+
+impl Drop for PyUriDemuxer {
+    fn drop(&mut self) {
+        if let Some(inner) = self.inner.take() {
+            // Move the demuxer to a detached thread so that the GC thread
+            // (which holds the GIL) does not block on GStreamer streaming
+            // threads that try to re-acquire the GIL via callbacks.
+            std::thread::spawn(move || {
+                drop(inner);
+            });
+        }
+    }
+}
+
 /// Register the GStreamer Python classes on the given module.
 ///
 /// The unified :class:`Codec` enum ([`PyVideoCodec`]) is also re-exported
@@ -560,5 +845,6 @@ pub fn register_classes(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyDemuxedPacket>()?;
     m.add_class::<PyMp4DemuxerOutput>()?;
     m.add_class::<PyMp4Demuxer>()?;
+    m.add_class::<PyUriDemuxer>()?;
     Ok(())
 }

--- a/savant_deepstream/buffers/src/sealed.rs
+++ b/savant_deepstream/buffers/src/sealed.rs
@@ -51,12 +51,18 @@
 //! ```
 
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use savant_core::primitives::frame::VideoFrameProxy;
 use savant_core::utils::release_seal::ReleaseSeal;
 
 use crate::SharedBuffer;
+
+/// Slice length used by [`Sealed::unseal`] when polling a not-yet-released
+/// seal. Each missed slice emits a single `log::warn!` carrying the seal id
+/// and payload type so that operators stuck on a never-released producer can
+/// be diagnosed from logs alone.
+const UNSEAL_WARN_INTERVAL: Duration = Duration::from_secs(5);
 
 /// A payload `T` gated by an [`Arc<ReleaseSeal>`].
 ///
@@ -98,8 +104,17 @@ pub struct Sealed<T> {
 impl<T> Sealed<T> {
     /// Wrap `payload` with the provided seal.  Callers typically clone
     /// the `Arc` held by the producing struct.
+    ///
+    /// Emits a `log::trace!` carrying the seal id and the payload type so
+    /// that subsequent `warn!` lines from [`Self::unseal`] can be correlated
+    /// back to the producer that originally minted the seal.
     #[inline]
     pub fn new(payload: T, seal: Arc<ReleaseSeal>) -> Self {
+        log::trace!(
+            "Sealed[{}]<{}> created",
+            seal.id(),
+            std::any::type_name::<T>()
+        );
         Self { payload, seal }
     }
 
@@ -111,10 +126,31 @@ impl<T> Sealed<T> {
 
     /// Block until the producer releases the seal, then yield the
     /// payload.
+    ///
+    /// The wait is internally chunked into [`UNSEAL_WARN_INTERVAL`]
+    /// (5-second) slices: every slice that elapses without the producer
+    /// releasing the seal triggers a single `log::warn!` line tagged with
+    /// the seal id and payload type. The method only returns once the
+    /// producer has actually released the seal.
     #[inline]
     pub fn unseal(self) -> T {
-        self.seal.wait();
-        self.payload
+        let start = Instant::now();
+        let mut iterations: u64 = 0;
+        loop {
+            if self.seal.wait_timeout(UNSEAL_WARN_INTERVAL) {
+                return self.payload;
+            }
+            iterations += 1;
+            log::warn!(
+                "Sealed[{}]<{}> unseal still blocked after {:.1}s ({} x {}s slices), \
+                 producer has not released yet",
+                self.seal.id(),
+                std::any::type_name::<T>(),
+                start.elapsed().as_secs_f64(),
+                iterations,
+                UNSEAL_WARN_INTERVAL.as_secs(),
+            );
+        }
     }
 
     /// Block until released or `timeout` expires.  On timeout, returns
@@ -143,6 +179,7 @@ impl<T> Sealed<T> {
 impl<T> std::fmt::Debug for Sealed<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Sealed")
+            .field("seal_id", &self.seal.id())
             .field("payload_type", &std::any::type_name::<T>())
             .field("released", &self.seal.is_released())
             .finish()
@@ -242,6 +279,72 @@ mod tests {
         assert!(!sealed.is_released());
         seal.release();
         assert!(sealed.is_released());
+    }
+
+    #[test]
+    fn unseal_warns_periodically_then_returns() {
+        // Verify the iterative unseal loop both (a) keeps blocking past one
+        // 5-second slice and (b) ultimately returns the payload once the
+        // producer releases. We don't assert the warn line text here (that
+        // would require an env_logger capture); the value of this test is
+        // the regression guard that the loop exits cleanly after at least
+        // one warn iteration has elapsed.
+        let seal = Arc::new(ReleaseSeal::new());
+        let sealed = Sealed::new(123u64, Arc::clone(&seal));
+
+        let releaser = thread::spawn({
+            let seal = Arc::clone(&seal);
+            move || {
+                thread::sleep(Duration::from_millis(5_500));
+                seal.release();
+            }
+        });
+
+        let started = std::time::Instant::now();
+        let value = sealed.unseal();
+        let elapsed = started.elapsed();
+
+        assert_eq!(value, 123u64);
+        assert!(
+            elapsed >= Duration::from_secs(5),
+            "unseal must have looped past at least one 5s slice (elapsed={:?})",
+            elapsed
+        );
+        releaser.join().unwrap();
+    }
+
+    #[test]
+    fn unseal_returns_immediately_when_already_released() {
+        let seal = Arc::new(ReleaseSeal::new());
+        seal.release();
+        let sealed = Sealed::new("ready", Arc::clone(&seal));
+        let started = std::time::Instant::now();
+        let value = sealed.unseal();
+        let elapsed = started.elapsed();
+        assert_eq!(value, "ready");
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "unseal must short-circuit when the seal is already released (elapsed={:?})",
+            elapsed
+        );
+    }
+
+    #[test]
+    fn debug_includes_seal_id() {
+        let seal = Arc::new(ReleaseSeal::new());
+        let id = seal.id();
+        let sealed = Sealed::new(0u8, seal);
+        let s = format!("{:?}", sealed);
+        assert!(
+            s.contains(&format!("seal_id: {}", id)),
+            "Debug output must include seal_id field, got: {}",
+            s
+        );
+        assert!(
+            s.contains("payload_type"),
+            "Debug output must include payload_type field, got: {}",
+            s
+        );
     }
 
     /// Compile-time positive check: `Sealed<T>` must be `Send`/`Sync`

--- a/savant_deepstream/inputs/src/flexible_decoder/decoder.rs
+++ b/savant_deepstream/inputs/src/flexible_decoder/decoder.rs
@@ -188,6 +188,10 @@ impl FlexibleDecoder {
             super::output::DecoderParameters,
             super::output::DecoderParameters,
         )>;
+        // Set when handle_active observed a worker death and committed Idle:
+        // phase 2 below re-runs handle_idle for the current packet so the
+        // restart is transparent to callers of `submit`.
+        let mut restart_reentry: bool = false;
 
         let result = {
             let mut state = self.state.lock();
@@ -268,7 +272,9 @@ impl FlexibleDecoder {
                     let resolve_ref = resolve_opt.as_ref().unwrap();
                     match handle_active(
                         guard,
+                        &mut pending,
                         &self.frame_map,
+                        &self.config.source_id,
                         decoder,
                         worker_join,
                         worker_stop,
@@ -281,6 +287,7 @@ impl FlexibleDecoder {
                     ) {
                         ActiveResult::SteadyState(r) => {
                             drain_job = None;
+                            restart_reentry = false;
                             r
                         }
                         ActiveResult::NeedDrain {
@@ -289,6 +296,17 @@ impl FlexibleDecoder {
                             new_params,
                         } => {
                             drain_job = Some((old_decoder, old_params, new_params));
+                            restart_reentry = false;
+                            Ok(())
+                        }
+                        ActiveResult::Restarted => {
+                            // The dead decoder has been torn down, the
+                            // frame map drained, and the state committed
+                            // back to Idle.  Phase 2 below re-runs
+                            // handle_idle for the current packet so the
+                            // restart is transparent to the caller.
+                            drain_job = None;
+                            restart_reentry = true;
                             Ok(())
                         }
                     }
@@ -324,6 +342,22 @@ impl FlexibleDecoder {
                 });
             }
             handle_result
+        } else if restart_reentry {
+            // Worker died: handle_active has already torn down the dead
+            // decoder, drained the frame map, and emitted the Restarted
+            // event into `pending`.  Re-run handle_idle so the current
+            // packet is processed against a freshly Idle state — the
+            // restart is therefore transparent to the caller.
+            let mut state = self.state.lock();
+            let (guard2, _taken) = StateGuard::take(&mut state);
+            handle_idle(
+                guard2,
+                &mut pending,
+                &self.frame_map,
+                resolve_opt.take().unwrap(),
+                &ctx,
+                &activate_fn,
+            )
         } else {
             result
         };

--- a/savant_deepstream/inputs/src/flexible_decoder/error.rs
+++ b/savant_deepstream/inputs/src/flexible_decoder/error.rs
@@ -7,8 +7,6 @@ use deepstream_decoders::DecoderError;
 pub enum FlexibleDecoderError {
     #[error("decoder is shut down")]
     ShutDown,
-    #[error("worker thread exited unexpectedly")]
-    WorkerDied,
     #[error("decoder error: {0}")]
     Decoder(#[from] DecoderError),
 }

--- a/savant_deepstream/inputs/src/flexible_decoder/handle_active.rs
+++ b/savant_deepstream/inputs/src/flexible_decoder/handle_active.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::thread::JoinHandle;
 
 use super::error::FlexibleDecoderError;
-use super::output::DecoderParameters;
+use super::output::{DecoderParameters, FlexibleDecoderOutput, SkipReason};
 use super::state::{register_frame, DecoderState, FrameMap, StateGuard, SubmitContext};
 
 /// Result of processing a submit in the `Active` state.
@@ -22,7 +22,25 @@ pub(crate) enum ActiveResult {
         old_params: DecoderParameters,
         new_params: DecoderParameters,
     },
+    /// The underlying [`NvDecoder`] worker died (e.g. the GstPipeline
+    /// watchdog tripped while frames were stuck in the `in_flight` map).
+    /// The state has been committed to `Idle`, the dead decoder has been
+    /// torn down, and `pending` has been populated with one
+    /// [`FlexibleDecoderOutput::Skipped`] per orphaned frame plus a
+    /// trailing aggregate
+    /// [`FlexibleDecoderOutput::Restarted`].  The caller must
+    /// re-acquire the state lock and re-run [`super::handle_idle::handle_idle`]
+    /// for `ctx`, exactly like the [`NeedDrain`](Self::NeedDrain) recovery
+    /// path — the restart is therefore transparent to
+    /// [`super::FlexibleDecoder::submit`].
+    Restarted,
 }
+
+/// Reason string surfaced via [`FlexibleDecoderOutput::Restarted`] when the
+/// worker thread exits unexpectedly.  The upstream
+/// [`PipelineError`](savant_gstreamer::pipeline::PipelineError) is reported
+/// separately via [`FlexibleDecoderOutput::Error`].
+const WORKER_DIED_REASON: &str = "worker thread exited";
 
 /// Handle a submit when the decoder is in `Active` state.
 ///
@@ -35,13 +53,19 @@ pub(crate) enum ActiveResult {
 /// On submit error: commits guard to `Active` (decoder still valid), returns
 /// `SteadyState(Err(...))`.
 ///
-/// On dead worker: tears down the decoder, commits guard to `Idle`, returns
-/// `SteadyState(Err(WorkerDied))`.  The next `submit` call will
-/// re-activate from scratch.
+/// On dead worker: tears down the decoder, drains the entire frame map
+/// into `pending` as
+/// [`Skipped { reason: DecoderRestarted(_) }`](FlexibleDecoderOutput::Skipped),
+/// pushes a [`FlexibleDecoderOutput::Restarted`] aggregate event, commits
+/// guard to `Idle`, and returns [`ActiveResult::Restarted`].  The caller is
+/// expected to re-run [`super::handle_idle::handle_idle`] for `ctx` so the
+/// restart is transparent to [`super::FlexibleDecoder::submit`].
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn handle_active(
     guard: StateGuard<'_>,
+    pending: &mut Vec<FlexibleDecoderOutput>,
     frame_map: &FrameMap,
+    source_id: &str,
     decoder: Arc<NvDecoder>,
     worker_join: Option<JoinHandle<()>>,
     worker_stop: Arc<AtomicBool>,
@@ -60,8 +84,32 @@ pub(crate) fn handle_active(
             let _ = jh.join();
         }
         let _ = decoder.shutdown();
+
+        // Drain any frames still mapped to the dead decoder so users see
+        // a per-frame Skipped(DecoderRestarted) plus the aggregate
+        // Restarted event below.
+        let lost_frames = {
+            let mut fm = frame_map.lock();
+            let mut lost = 0usize;
+            for (_, frame) in fm.drain() {
+                lost += 1;
+                pending.push(FlexibleDecoderOutput::Skipped {
+                    frame,
+                    data: None,
+                    reason: SkipReason::DecoderRestarted(WORKER_DIED_REASON.to_string()),
+                });
+            }
+            lost
+        };
+
+        pending.push(FlexibleDecoderOutput::Restarted {
+            source_id: source_id.to_string(),
+            reason: WORKER_DIED_REASON.to_string(),
+            lost_frames,
+        });
+
         guard.commit(DecoderState::Idle);
-        return ActiveResult::SteadyState(Err(FlexibleDecoderError::WorkerDied));
+        return ActiveResult::Restarted;
     }
 
     let codec_changed = ctx.video_codec != Some(active_video_codec);

--- a/savant_deepstream/inputs/src/flexible_decoder/handle_detecting.rs
+++ b/savant_deepstream/inputs/src/flexible_decoder/handle_detecting.rs
@@ -12,17 +12,22 @@ use super::state::{
 
 /// Handle a submit when the decoder is in `Detecting` state.
 ///
-/// On the first random access point (IDR / I-frame) the decoder is activated
-/// and the current packet is submitted to it.  Any packets buffered during
-/// detection are **discarded** with [`SkipReason::WaitingForKeyframe`] —
-/// they cannot be decoded without the IDR as anchor and replaying them only
-/// leaks PTS entries into the underlying GstPipeline `in_flight` map, which
-/// later trips the watchdog.  If the user wants those frames anyway they
-/// can observe them through the `Skipped` callback.
+/// On the first random access point (IDR / I-frame) the decoder is
+/// activated and the IDR is submitted to it.  Once the IDR is safely
+/// accepted, the previously-buffered pre-RAP packets are emitted as
+/// [`SkipReason::WaitingForKeyframe`] — they cannot be decoded without the
+/// IDR as anchor and replaying them only leaks PTS entries into the
+/// underlying GstPipeline `in_flight` map, which later trips the watchdog.
+/// If the user wants those frames anyway they can observe them through the
+/// `Skipped` callback.
 ///
 /// If activation fails, both the buffered packets and the current one are
 /// emitted as `Skipped(DecoderCreationFailed)` and the state is reset to
-/// `Idle`.
+/// `Idle`.  If activation succeeds but the IDR's first
+/// [`NvDecoder::submit_packet`](deepstream_decoders::NvDecoder::submit_packet)
+/// errors, the buffered packets are emitted as
+/// `Skipped(DecoderCreationFailed)` (they share the same root cause) and
+/// the IDR itself is surfaced through the returned `Err`.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn handle_detecting(
     guard: StateGuard<'_>,
@@ -42,17 +47,13 @@ pub(crate) fn handle_detecting(
             let real_gst_codec = cfg.codec();
             match activate(cfg, real_gst_codec, width, height, ctx.frame) {
                 Ok((decoder, worker_join, worker_stop)) => {
-                    // Discard pre-RAP packets: they would never decode
-                    // without an anchor IDR and replaying them strands
-                    // their PTS in the GstPipeline watchdog map.
-                    for pkt in buffered.drain(..) {
-                        pending.push(FlexibleDecoderOutput::Skipped {
-                            frame: pkt.frame,
-                            data: Some(pkt.data),
-                            reason: SkipReason::WaitingForKeyframe,
-                        });
-                    }
-
+                    // Try the IDR first; only after it is safely accepted
+                    // by the decoder do we drain the buffered pre-RAP
+                    // packets as `WaitingForKeyframe`.  Draining them up
+                    // front would mislabel them on the failure path: if
+                    // `submit_packet` errors, the buffered frames were
+                    // orphaned by the same decoder failure, not by routine
+                    // pre-keyframe skipping.
                     register_frame(frame_map, ctx.frame_id, ctx.frame);
                     match decoder.submit_packet(
                         ctx.payload,
@@ -62,6 +63,17 @@ pub(crate) fn handle_detecting(
                         ctx.clk.duration_ns,
                     ) {
                         Ok(()) => {
+                            // IDR accepted — pre-RAP packets were truly
+                            // skipped while waiting for a keyframe.
+                            // Replaying them would strand their PTS in the
+                            // GstPipeline watchdog map.
+                            for pkt in buffered.drain(..) {
+                                pending.push(FlexibleDecoderOutput::Skipped {
+                                    frame: pkt.frame,
+                                    data: Some(pkt.data),
+                                    reason: SkipReason::WaitingForKeyframe,
+                                });
+                            }
                             guard.commit(DecoderState::Active {
                                 decoder,
                                 worker_join: Some(worker_join),
@@ -76,6 +88,21 @@ pub(crate) fn handle_detecting(
                         Err(e) => {
                             teardown_activated(&decoder, worker_join, &worker_stop);
                             frame_map.lock().remove(&ctx.frame_id);
+                            // Surface the buffered frames with the same
+                            // reason as the activation-failure branch
+                            // below — the freshly-created decoder rejected
+                            // its very first packet, so those dependent
+                            // pre-RAP frames are lost for the same reason.
+                            // The IDR itself is reported via the returned
+                            // `Err`, matching the existing contract.
+                            let reason_str = format!("{e}");
+                            for pkt in buffered.drain(..) {
+                                pending.push(FlexibleDecoderOutput::Skipped {
+                                    frame: pkt.frame,
+                                    data: Some(pkt.data),
+                                    reason: SkipReason::DecoderCreationFailed(reason_str.clone()),
+                                });
+                            }
                             guard.commit(DecoderState::Idle);
                             return Err(e.into());
                         }

--- a/savant_deepstream/inputs/src/flexible_decoder/handle_detecting.rs
+++ b/savant_deepstream/inputs/src/flexible_decoder/handle_detecting.rs
@@ -12,10 +12,17 @@ use super::state::{
 
 /// Handle a submit when the decoder is in `Detecting` state.
 ///
-/// On activation, replays buffered packets. If any replay submission fails,
-/// the entire activation is aborted: the decoder is torn down, all buffered
-/// packets (plus the current one) are emitted as `Skipped`, and the guard
-/// is committed to `Idle`.
+/// On the first random access point (IDR / I-frame) the decoder is activated
+/// and the current packet is submitted to it.  Any packets buffered during
+/// detection are **discarded** with [`SkipReason::WaitingForKeyframe`] —
+/// they cannot be decoded without the IDR as anchor and replaying them only
+/// leaks PTS entries into the underlying GstPipeline `in_flight` map, which
+/// later trips the watchdog.  If the user wants those frames anyway they
+/// can observe them through the `Skipped` callback.
+///
+/// If activation fails, both the buffered packets and the current one are
+/// emitted as `Skipped(DecoderCreationFailed)` and the state is reset to
+/// `Idle`.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn handle_detecting(
     guard: StateGuard<'_>,
@@ -35,46 +42,15 @@ pub(crate) fn handle_detecting(
             let real_gst_codec = cfg.codec();
             match activate(cfg, real_gst_codec, width, height, ctx.frame) {
                 Ok((decoder, worker_join, worker_stop)) => {
-                    let mut registered_ids: Vec<u128> = Vec::new();
-                    let mut replay_err: Option<String> = None;
-
-                    for pkt in &buffered {
-                        register_frame(frame_map, pkt.frame_id, &pkt.frame);
-                        registered_ids.push(pkt.frame_id);
-                        if let Err(e) = decoder.submit_packet(
-                            &pkt.data,
-                            pkt.frame_id,
-                            pkt.pts_ns,
-                            pkt.dts_ns,
-                            pkt.duration_ns,
-                        ) {
-                            replay_err = Some(format!("buffered packet replay failed: {e}"));
-                            break;
-                        }
-                    }
-
-                    if let Some(err_msg) = replay_err {
-                        teardown_activated(&decoder, worker_join, &worker_stop);
-                        {
-                            let mut fm = frame_map.lock();
-                            for id in &registered_ids {
-                                fm.remove(id);
-                            }
-                        }
-                        for pkt in buffered {
-                            pending.push(FlexibleDecoderOutput::Skipped {
-                                frame: pkt.frame,
-                                data: Some(pkt.data),
-                                reason: SkipReason::DecoderCreationFailed(err_msg.clone()),
-                            });
-                        }
+                    // Discard pre-RAP packets: they would never decode
+                    // without an anchor IDR and replaying them strands
+                    // their PTS in the GstPipeline watchdog map.
+                    for pkt in buffered.drain(..) {
                         pending.push(FlexibleDecoderOutput::Skipped {
-                            frame: ctx.frame.clone(),
-                            data: Some(ctx.payload.to_vec()),
-                            reason: SkipReason::DecoderCreationFailed(err_msg),
+                            frame: pkt.frame,
+                            data: Some(pkt.data),
+                            reason: SkipReason::WaitingForKeyframe,
                         });
-                        guard.commit(DecoderState::Idle);
-                        return Ok(());
                     }
 
                     register_frame(frame_map, ctx.frame_id, ctx.frame);
@@ -99,13 +75,7 @@ pub(crate) fn handle_detecting(
                         }
                         Err(e) => {
                             teardown_activated(&decoder, worker_join, &worker_stop);
-                            {
-                                let mut fm = frame_map.lock();
-                                for id in &registered_ids {
-                                    fm.remove(id);
-                                }
-                                fm.remove(&ctx.frame_id);
-                            }
+                            frame_map.lock().remove(&ctx.frame_id);
                             guard.commit(DecoderState::Idle);
                             return Err(e.into());
                         }
@@ -133,11 +103,7 @@ pub(crate) fn handle_detecting(
 
     buffered.push(BufferedPacket {
         frame: ctx.frame.clone(),
-        frame_id: ctx.frame_id,
         data: ctx.payload.to_vec(),
-        pts_ns: ctx.clk.submission_order_ns,
-        dts_ns: ctx.clk.dts_ns,
-        duration_ns: ctx.clk.duration_ns,
     });
 
     if buffered.len() > detect_buffer_limit {

--- a/savant_deepstream/inputs/src/flexible_decoder/handle_idle.rs
+++ b/savant_deepstream/inputs/src/flexible_decoder/handle_idle.rs
@@ -144,11 +144,7 @@ pub(crate) fn handle_idle(
 
             buffered.push(BufferedPacket {
                 frame: ctx.frame.clone(),
-                frame_id: ctx.frame_id,
                 data: ctx.payload.to_vec(),
-                pts_ns: ctx.clk.submission_order_ns,
-                dts_ns: ctx.clk.dts_ns,
-                duration_ns: ctx.clk.duration_ns,
             });
             guard.commit(DecoderState::Detecting {
                 strategy,

--- a/savant_deepstream/inputs/src/flexible_decoder/output.rs
+++ b/savant_deepstream/inputs/src/flexible_decoder/output.rs
@@ -69,6 +69,32 @@ pub enum FlexibleDecoderOutput {
     Event(gst::Event),
     /// Error from the underlying `NvDecoder`.
     Error(DecoderError),
+    /// The decoder was torn down (typically because the underlying GStreamer
+    /// pipeline's watchdog tripped) and the [`super::FlexibleDecoder`] has
+    /// transitioned back to `Idle`.  The next submit re-runs detection /
+    /// activation transparently; any frames that were in flight when the
+    /// decoder died are surfaced individually as
+    /// [`Skipped`](Self::Skipped) with
+    /// [`SkipReason::DecoderRestarted`].
+    ///
+    /// This event is purely informational — the pool has already taken the
+    /// recovery action by the time the callback fires.  Hooks may use it to
+    /// log, increment metrics, or request a cooperative pipeline stop.
+    Restarted {
+        /// Source id of the [`super::FlexibleDecoder`] that restarted.
+        source_id: String,
+        /// Human-readable reason for the restart.  Currently always
+        /// `"worker thread exited"` (typically watchdog-induced; the
+        /// upstream [`PipelineError`](savant_gstreamer::pipeline::PipelineError)
+        /// is reported separately via
+        /// [`Error`](Self::Error)`(FrameworkError(...))`).
+        reason: String,
+        /// Number of in-flight frames that were lost because of the
+        /// restart.  Each is also surfaced via
+        /// [`Skipped`](Self::Skipped) with
+        /// [`SkipReason::DecoderRestarted`].
+        lost_frames: usize,
+    },
 }
 
 impl FlexibleDecoderOutput {
@@ -129,4 +155,9 @@ pub enum SkipReason {
     InvalidPayload(String),
     /// `NvDecoder::new()` failed when activating.
     DecoderCreationFailed(String),
+    /// The decoder was torn down (typically a watchdog-induced restart) while
+    /// this frame was in flight; it could not be recovered.  The aggregate
+    /// signal is delivered via
+    /// [`FlexibleDecoderOutput::Restarted`].
+    DecoderRestarted(String),
 }

--- a/savant_deepstream/inputs/src/flexible_decoder/state.rs
+++ b/savant_deepstream/inputs/src/flexible_decoder/state.rs
@@ -32,13 +32,17 @@ pub(crate) type ActivateFn<'a> = dyn Fn(DecoderConfig, VideoCodec, i64, i64, &Vi
     + 'a;
 
 /// Packet buffered during H.264/HEVC stream detection.
+///
+/// Pre-RAP packets cannot be decoded without an anchor IDR, so once the
+/// first random access point arrives the buffered queue is **drained as
+/// `Skipped(WaitingForKeyframe)`** rather than replayed (replaying would
+/// only strand PTS entries in the GstPipeline watchdog map).  Only
+/// `frame` (for the [`Skipped`](super::output::FlexibleDecoderOutput::Skipped)
+/// frame proxy) and `data` (for the [`Skipped::data`](super::output::FlexibleDecoderOutput::Skipped)
+/// payload) are needed downstream.
 pub(crate) struct BufferedPacket {
     pub frame: VideoFrameProxy,
-    pub frame_id: u128,
     pub data: Vec<u8>,
-    pub pts_ns: u64,
-    pub dts_ns: Option<u64>,
-    pub duration_ns: Option<u64>,
 }
 
 /// Internal decoder lifecycle state.

--- a/savant_deepstream/inputs/tests/common/mod.rs
+++ b/savant_deepstream/inputs/tests/common/mod.rs
@@ -406,6 +406,11 @@ pub enum CollectedOutput {
     },
     Event,
     Error(String),
+    Restarted {
+        source_id: String,
+        reason: String,
+        lost_frames: usize,
+    },
 }
 
 impl CollectedOutput {
@@ -448,6 +453,15 @@ impl CollectedOutput {
             },
             FlexibleDecoderOutput::Event(_) => CollectedOutput::Event,
             FlexibleDecoderOutput::Error(e) => CollectedOutput::Error(format!("{e}")),
+            FlexibleDecoderOutput::Restarted {
+                source_id,
+                reason,
+                lost_frames,
+            } => CollectedOutput::Restarted {
+                source_id: source_id.clone(),
+                reason: reason.clone(),
+                lost_frames: *lost_frames,
+            },
         }
     }
 }

--- a/savant_deepstream/inputs/tests/test_flexible_decoder_real.rs
+++ b/savant_deepstream/inputs/tests/test_flexible_decoder_real.rs
@@ -918,6 +918,133 @@ fn test_h264_wrong_frame_dimensions() {
 }
 
 // ═══════════════════════════════════════════════════════════════════
+//  Pre-IDR skip (regression for watchdog timeout from replayed P-frames)
+// ═══════════════════════════════════════════════════════════════════
+
+/// When a stream starts with non-RAP packets (typical for live RTSP feeds
+/// joined mid-GOP), [`FlexibleDecoder`] must not replay them once the
+/// first IDR finally arrives — replaying P-frames without an anchor IDR
+/// strands their PTS in the GstPipeline `in_flight` map and trips the
+/// watchdog. They must instead be surfaced as
+/// [`SkipReason::WaitingForKeyframe`] when activation succeeds.
+///
+/// The test reorders a real H.264 Annex-B stream so the leading P-frames
+/// arrive before the IDR (which is normally first). It then verifies the
+/// pre-IDR P-frames produce `Skipped(WaitingForKeyframe)` and the IDR
+/// itself decodes successfully.
+#[test]
+#[serial]
+fn test_pre_idr_packets_skipped_not_replayed() {
+    init();
+    let manifest = load_manifest();
+    let Some(entry) = find_entry(&manifest, "test_h264_annexb_ip.h264") else {
+        return;
+    };
+
+    let collector = OutputCollector::new();
+    let dec = FlexibleDecoder::new(default_config(), collector.callback());
+    let aus = load_annexb_access_units(entry);
+    assert!(
+        aus.len() >= 6,
+        "test asset must have at least 6 access units"
+    );
+
+    // The first AU of an Annex-B IP stream carries SPS+PPS+IDR; skip it
+    // initially and feed the next 5 (pure P-frames) so the decoder enters
+    // `Detecting` and buffers them.
+    const NUM_PRE_IDR: usize = 5;
+    let vc = savant_core::primitives::video_codec::VideoCodec::H264;
+    let width = entry.width as i64;
+    let height = entry.height as i64;
+
+    let mut p_frame_uuids = Vec::with_capacity(NUM_PRE_IDR);
+    for au in aus.iter().skip(1).take(NUM_PRE_IDR) {
+        let frame = make_video_frame_ns(
+            SOURCE_ID,
+            vc,
+            width,
+            height,
+            au.pts_ns as i64,
+            au.dts_ns.map(|d| d as i64),
+            au.duration_ns.map(|d| d as i64),
+            None,
+        );
+        p_frame_uuids.push(frame.get_uuid_u128());
+        dec.submit(&frame, Some(&au.data))
+            .expect("submit pre-IDR P-frame");
+    }
+
+    // Now submit the IDR (AU[0]) → activation runs, buffered P-frames must
+    // be drained as `WaitingForKeyframe` and only the IDR submitted to the
+    // underlying NvDecoder.
+    let idr = &aus[0];
+    let idr_frame = make_video_frame_ns(
+        SOURCE_ID,
+        vc,
+        width,
+        height,
+        // Bump the IDR's PTS past the buffered P-frames so DTS ordering is
+        // monotonic at NvDecoder ingress (StrictDecodeOrder).
+        (NUM_PRE_IDR as u64 * 33_333_333 + idr.pts_ns) as i64,
+        Some((NUM_PRE_IDR as u64 * 33_333_333) as i64),
+        idr.duration_ns.map(|d| d as i64),
+        Some(true),
+    );
+    let idr_uuid = idr_frame.get_uuid_u128();
+    dec.submit(&idr_frame, Some(&idr.data))
+        .expect("submit IDR");
+
+    // Drain so the IDR-decoded frame surfaces through the callback.
+    dec.graceful_shutdown().unwrap();
+
+    let outputs = collector.drain();
+
+    let skipped: Vec<&CollectedOutput> = outputs
+        .iter()
+        .filter(|o| {
+            matches!(
+                o,
+                CollectedOutput::Skipped { reason } if reason.contains("WaitingForKeyframe")
+            )
+        })
+        .collect();
+    assert_eq!(
+        skipped.len(),
+        NUM_PRE_IDR,
+        "every pre-IDR P-frame must be skipped as WaitingForKeyframe; got {} of {}: {outputs:?}",
+        skipped.len(),
+        NUM_PRE_IDR
+    );
+
+    // Pre-IDR packets must NEVER reach NvDecoder, so no decoder errors.
+    let errors: Vec<&CollectedOutput> = outputs
+        .iter()
+        .filter(|o| matches!(o, CollectedOutput::Error(_)))
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "pre-IDR drain must not emit decoder errors: {errors:?}"
+    );
+
+    // The IDR itself must decode successfully.
+    let idr_frames: Vec<&CollectedOutput> = outputs
+        .iter()
+        .filter(|o| matches!(o, CollectedOutput::Frame { proxy_uuid, .. } if *proxy_uuid == idr_uuid))
+        .collect();
+    assert_eq!(
+        idr_frames.len(),
+        1,
+        "IDR must be decoded exactly once; got {}: {outputs:?}",
+        idr_frames.len()
+    );
+
+    eprintln!(
+        "  OK test_pre_idr_packets_skipped_not_replayed: {} pre-IDR P-frames skipped, IDR decoded",
+        NUM_PRE_IDR
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════
 //  Sealed delivery — cross-thread unseal
 // ═══════════════════════════════════════════════════════════════════
 

--- a/savant_deepstream/inputs/tests/test_flexible_decoder_real.rs
+++ b/savant_deepstream/inputs/tests/test_flexible_decoder_real.rs
@@ -991,8 +991,7 @@ fn test_pre_idr_packets_skipped_not_replayed() {
         Some(true),
     );
     let idr_uuid = idr_frame.get_uuid_u128();
-    dec.submit(&idr_frame, Some(&idr.data))
-        .expect("submit IDR");
+    dec.submit(&idr_frame, Some(&idr.data)).expect("submit IDR");
 
     // Drain so the IDR-decoded frame surfaces through the callback.
     dec.graceful_shutdown().unwrap();
@@ -1029,7 +1028,9 @@ fn test_pre_idr_packets_skipped_not_replayed() {
     // The IDR itself must decode successfully.
     let idr_frames: Vec<&CollectedOutput> = outputs
         .iter()
-        .filter(|o| matches!(o, CollectedOutput::Frame { proxy_uuid, .. } if *proxy_uuid == idr_uuid))
+        .filter(
+            |o| matches!(o, CollectedOutput::Frame { proxy_uuid, .. } if *proxy_uuid == idr_uuid),
+        )
         .collect();
     assert_eq!(
         idr_frames.len(),

--- a/savant_gstreamer/savant_gstreamer/Cargo.toml
+++ b/savant_gstreamer/savant_gstreamer/Cargo.toml
@@ -30,5 +30,6 @@ savant_core = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+cros-codecs = { workspace = true }
 crossbeam = { workspace = true }
 env_logger = "0.11"

--- a/savant_gstreamer/savant_gstreamer/Cargo.toml
+++ b/savant_gstreamer/savant_gstreamer/Cargo.toml
@@ -32,4 +32,6 @@ thiserror = { workspace = true }
 [dev-dependencies]
 cros-codecs = { workspace = true }
 crossbeam = { workspace = true }
-env_logger = "0.11"
+env_logger = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/savant_gstreamer/savant_gstreamer/src/demux.rs
+++ b/savant_gstreamer/savant_gstreamer/src/demux.rs
@@ -1,0 +1,30 @@
+//! Common demuxer data types shared between `mp4_demuxer` and `uri_demuxer`.
+
+pub mod helpers;
+
+use savant_core::primitives::video_codec::VideoCodec;
+
+/// A single demuxed elementary stream packet.
+#[derive(Debug, Clone)]
+pub struct DemuxedPacket {
+    pub data: Vec<u8>,
+    pub pts_ns: u64,
+    pub dts_ns: Option<u64>,
+    pub duration_ns: Option<u64>,
+    pub is_keyframe: bool,
+}
+
+/// Video-stream metadata extracted from container caps at demux time.
+///
+/// Dimensions are the **encoded** width/height — QuickTime display-orientation
+/// metadata is NOT applied.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VideoInfo {
+    pub codec: VideoCodec,
+    pub width: u32,
+    pub height: u32,
+    /// Framerate numerator. `0` if the container does not advertise a rate.
+    pub framerate_num: u32,
+    /// Framerate denominator. `1` if the container does not advertise a rate.
+    pub framerate_den: u32,
+}

--- a/savant_gstreamer/savant_gstreamer/src/demux/helpers.rs
+++ b/savant_gstreamer/savant_gstreamer/src/demux/helpers.rs
@@ -1,0 +1,252 @@
+use gstreamer as gst;
+use gstreamer::prelude::*;
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Condvar, Mutex};
+
+use savant_core::primitives::video_codec::VideoCodec;
+
+/// Error building the parser + capsfilter chain; caller maps to its demuxer error type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ParserChainError(pub String);
+
+/// Error converting a GStreamer sample to a demuxed packet; caller maps to its demuxer error type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SampleError {
+    pub src: String,
+    pub msg: String,
+    pub debug: String,
+}
+
+/// Notify the condvar that the demuxer is done.
+pub(crate) fn signal_done(done_pair: &(Mutex<bool>, Condvar)) {
+    let (lock, cvar) = done_pair;
+    *lock.lock().unwrap() = true;
+    cvar.notify_all();
+}
+
+/// Notify the condvar that stream info is known or unavailable because the
+/// pipeline has already terminated.
+pub(crate) fn signal_info_done(info_pair: &(Mutex<bool>, Condvar)) {
+    let (lock, cvar) = info_pair;
+    *lock.lock().unwrap() = true;
+    cvar.notify_all();
+}
+
+/// Build [`super::VideoInfo`] from caps, when enough fields are available.
+pub(crate) fn video_info_from_caps(caps: &gst::CapsRef) -> Option<super::VideoInfo> {
+    let codec = codec_from_caps(caps)?;
+    let s = caps.structure(0)?;
+    let width = s
+        .get::<i32>("width")
+        .ok()
+        .and_then(|v| u32::try_from(v).ok())?;
+    let height = s
+        .get::<i32>("height")
+        .ok()
+        .and_then(|v| u32::try_from(v).ok())?;
+    let (framerate_num, framerate_den) = s
+        .get::<gst::Fraction>("framerate")
+        .ok()
+        .map(|f| (u32::try_from(f.numer()).ok(), u32::try_from(f.denom()).ok()))
+        .map(|(num, den)| (num.unwrap_or(0), den.unwrap_or(1)))
+        .unwrap_or((0, 1));
+    Some(super::VideoInfo {
+        codec,
+        width,
+        height,
+        framerate_num,
+        framerate_den,
+    })
+}
+
+/// Try to detect and emit stream info from caps exactly once.
+pub(crate) fn maybe_emit_stream_info_from_caps<E>(
+    caps: Option<&gstreamer::CapsRef>,
+    detected_codec: &Mutex<Option<VideoCodec>>,
+    video_info: &Mutex<Option<super::VideoInfo>>,
+    stream_info_fired: &AtomicBool,
+    info_pair: &(Mutex<bool>, Condvar),
+    emit_stream_info: &E,
+) where
+    E: Fn(super::VideoInfo) + Send + Sync + ?Sized,
+{
+    let Some(caps) = caps else {
+        return;
+    };
+
+    let maybe_codec = codec_from_caps(caps);
+    if let Some(codec) = maybe_codec {
+        let mut detected_codec_guard = detected_codec.lock().unwrap();
+        if detected_codec_guard.is_none() {
+            *detected_codec_guard = Some(codec);
+        }
+    }
+
+    let Some(info) = video_info_from_caps(caps) else {
+        return;
+    };
+
+    // Write `video_info` before flipping `stream_info_fired` so readers that
+    // take the fast path (`stream_info_fired.load()` -> `video_info()`) never
+    // observe the atomic set without the corresponding `video_info` value.
+    {
+        let mut guard = video_info.lock().unwrap();
+        if guard.is_some() {
+            return;
+        }
+        *guard = Some(info);
+    }
+
+    if stream_info_fired
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_ok()
+    {
+        signal_info_done(info_pair);
+        emit_stream_info(info);
+    }
+}
+
+/// Convert a GStreamer sample to a [`super::DemuxedPacket`], updating
+/// `detected_codec` on the first sample with caps.
+pub(crate) fn sample_to_packet<E>(
+    sample: gst::Sample,
+    detected_codec: &Mutex<Option<VideoCodec>>,
+    video_info: &Mutex<Option<super::VideoInfo>>,
+    stream_info_fired: &AtomicBool,
+    info_pair: &(Mutex<bool>, Condvar),
+    emit_stream_info: &E,
+) -> Result<super::DemuxedPacket, SampleError>
+where
+    E: Fn(super::VideoInfo) + Send + Sync + ?Sized,
+{
+    maybe_emit_stream_info_from_caps(
+        sample.caps(),
+        detected_codec,
+        video_info,
+        stream_info_fired,
+        info_pair,
+        emit_stream_info,
+    );
+
+    let Some(buffer) = sample.buffer() else {
+        return Err(SampleError {
+            src: "appsink".to_string(),
+            msg: "sample has no buffer".to_string(),
+            debug: String::new(),
+        });
+    };
+    let map = buffer.map_readable().map_err(|e| SampleError {
+        src: "appsink".to_string(),
+        msg: format!("unable to map buffer: {e}"),
+        debug: String::new(),
+    })?;
+    let pts_ns = buffer.pts().map(|t| t.nseconds()).unwrap_or(0);
+    let dts_ns = buffer.dts().map(|t| t.nseconds());
+    let duration_ns = buffer.duration().map(|t| t.nseconds());
+    let is_keyframe = !buffer.flags().contains(gst::BufferFlags::DELTA_UNIT);
+    Ok(super::DemuxedPacket {
+        data: map.as_slice().to_vec(),
+        pts_ns,
+        dts_ns,
+        duration_ns,
+        is_keyframe,
+    })
+}
+
+/// Map GStreamer caps to a [`VideoCodec`] value.
+pub(crate) fn codec_from_caps(caps: &gst::CapsRef) -> Option<VideoCodec> {
+    let s = caps.structure(0)?;
+    match s.name().as_str() {
+        "video/x-h264" => Some(VideoCodec::H264),
+        "video/x-h265" => Some(VideoCodec::Hevc),
+        "video/x-av1" => Some(VideoCodec::Av1),
+        "video/x-vp8" => Some(VideoCodec::Vp8),
+        "video/x-vp9" => Some(VideoCodec::Vp9),
+        "image/jpeg" => Some(VideoCodec::Jpeg),
+        "image/png" => Some(VideoCodec::Png),
+        _ => None,
+    }
+}
+
+/// Dynamically insert a codec-specific parser (+ byte-stream capsfilter for
+/// H.264/HEVC) between the qtdemux pad and the queue.  Returns the parser's
+/// sink pad so the caller can link qtdemux's src_pad to it.
+pub(crate) fn build_parser_chain(
+    pipeline: &gst::Pipeline,
+    codec_name: Option<&str>,
+    queue_sink_pad: &gst::Pad,
+) -> Result<gst::Pad, ParserChainError> {
+    let (factory, needs_byte_stream_caps) = match codec_name {
+        Some("video/x-h264") => ("h264parse", true),
+        Some("video/x-h265") => ("h265parse", true),
+        Some("video/x-av1") => ("av1parse", false),
+        Some("video/x-vp8") => ("vp8parse", false),
+        Some("video/x-vp9") => ("vp9parse", false),
+        Some("image/jpeg") => ("jpegparse", false),
+        _ => return Err(ParserChainError("no parser needed".into())),
+    };
+
+    let parser = gst::ElementFactory::make(factory)
+        .name("demux-parser")
+        .build()
+        .map_err(|e| ParserChainError(format!("{factory}: {e}")))?;
+
+    if needs_byte_stream_caps {
+        parser.set_property("config-interval", -1i32);
+    }
+
+    pipeline
+        .add(&parser)
+        .map_err(|e| ParserChainError(format!("add parser: {e}")))?;
+
+    if needs_byte_stream_caps {
+        let media = if factory == "h264parse" {
+            "video/x-h264"
+        } else {
+            "video/x-h265"
+        };
+        let caps = gst::Caps::builder(media)
+            .field("stream-format", "byte-stream")
+            .build();
+        let capsfilter = gst::ElementFactory::make("capsfilter")
+            .name("demux-parser-capsf")
+            .property("caps", &caps)
+            .build()
+            .map_err(|e| ParserChainError(format!("capsfilter: {e}")))?;
+
+        pipeline
+            .add(&capsfilter)
+            .map_err(|e| ParserChainError(format!("add capsfilter: {e}")))?;
+
+        parser
+            .link(&capsfilter)
+            .map_err(|e| ParserChainError(format!("parser->capsfilter: {e}")))?;
+
+        let capsf_src = capsfilter
+            .static_pad("src")
+            .ok_or_else(|| ParserChainError("capsfilter src pad".into()))?;
+        capsf_src
+            .link(queue_sink_pad)
+            .map_err(|e| ParserChainError(format!("capsfilter->queue: {e}")))?;
+
+        capsfilter
+            .sync_state_with_parent()
+            .map_err(|_| ParserChainError("StateChangeFailed".into()))?;
+    } else {
+        let parser_src = parser
+            .static_pad("src")
+            .ok_or_else(|| ParserChainError("parser src pad".into()))?;
+        parser_src
+            .link(queue_sink_pad)
+            .map_err(|e| ParserChainError(format!("parser->queue: {e}")))?;
+    }
+
+    parser
+        .sync_state_with_parent()
+        .map_err(|_| ParserChainError("StateChangeFailed".into()))?;
+
+    parser
+        .static_pad("sink")
+        .ok_or_else(|| ParserChainError("parser sink pad missing".into()))
+}

--- a/savant_gstreamer/savant_gstreamer/src/demux/helpers.rs
+++ b/savant_gstreamer/savant_gstreamer/src/demux/helpers.rs
@@ -6,9 +6,30 @@ use std::sync::{Condvar, Mutex};
 
 use savant_core::primitives::video_codec::VideoCodec;
 
-/// Error building the parser + capsfilter chain; caller maps to its demuxer error type.
+/// Error building the parser + capsfilter chain.
+///
+/// Variants are preserved as distinct categories so callers can map them to
+/// their own structured error types (e.g. `LinkError` vs `ElementCreation`)
+/// without losing the failure class.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct ParserChainError(pub String);
+pub(crate) enum ParserChainError {
+    /// Failed to create or query a GStreamer element / pad.
+    ElementCreation(String),
+    /// Failed to add or link an element in the parser chain.
+    LinkError(String),
+    /// `sync_state_with_parent` (or equivalent) failed.
+    StateChangeFailed(String),
+}
+
+impl std::fmt::Display for ParserChainError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ElementCreation(s) => write!(f, "{s}"),
+            Self::LinkError(s) => write!(f, "{s}"),
+            Self::StateChangeFailed(s) => write!(f, "{s}"),
+        }
+    }
+}
 
 /// Error converting a GStreamer sample to a demuxed packet; caller maps to its demuxer error type.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -184,13 +205,13 @@ pub(crate) fn build_parser_chain(
         Some("video/x-vp8") => ("vp8parse", false),
         Some("video/x-vp9") => ("vp9parse", false),
         Some("image/jpeg") => ("jpegparse", false),
-        _ => return Err(ParserChainError("no parser needed".into())),
+        _ => return Err(ParserChainError::ElementCreation("no parser needed".into())),
     };
 
     let parser = gst::ElementFactory::make(factory)
         .name("demux-parser")
         .build()
-        .map_err(|e| ParserChainError(format!("{factory}: {e}")))?;
+        .map_err(|e| ParserChainError::ElementCreation(format!("{factory}: {e}")))?;
 
     if needs_byte_stream_caps {
         parser.set_property("config-interval", -1i32);
@@ -198,7 +219,7 @@ pub(crate) fn build_parser_chain(
 
     pipeline
         .add(&parser)
-        .map_err(|e| ParserChainError(format!("add parser: {e}")))?;
+        .map_err(|e| ParserChainError::LinkError(format!("add parser: {e}")))?;
 
     if needs_byte_stream_caps {
         let media = if factory == "h264parse" {
@@ -213,40 +234,40 @@ pub(crate) fn build_parser_chain(
             .name("demux-parser-capsf")
             .property("caps", &caps)
             .build()
-            .map_err(|e| ParserChainError(format!("capsfilter: {e}")))?;
+            .map_err(|e| ParserChainError::ElementCreation(format!("capsfilter: {e}")))?;
 
         pipeline
             .add(&capsfilter)
-            .map_err(|e| ParserChainError(format!("add capsfilter: {e}")))?;
+            .map_err(|e| ParserChainError::LinkError(format!("add capsfilter: {e}")))?;
 
         parser
             .link(&capsfilter)
-            .map_err(|e| ParserChainError(format!("parser->capsfilter: {e}")))?;
+            .map_err(|e| ParserChainError::LinkError(format!("parser->capsfilter: {e}")))?;
 
         let capsf_src = capsfilter
             .static_pad("src")
-            .ok_or_else(|| ParserChainError("capsfilter src pad".into()))?;
+            .ok_or_else(|| ParserChainError::ElementCreation("capsfilter src pad".into()))?;
         capsf_src
             .link(queue_sink_pad)
-            .map_err(|e| ParserChainError(format!("capsfilter->queue: {e}")))?;
+            .map_err(|e| ParserChainError::LinkError(format!("capsfilter->queue: {e}")))?;
 
-        capsfilter
-            .sync_state_with_parent()
-            .map_err(|_| ParserChainError("StateChangeFailed".into()))?;
+        capsfilter.sync_state_with_parent().map_err(|_| {
+            ParserChainError::StateChangeFailed("capsfilter sync_state_with_parent".into())
+        })?;
     } else {
         let parser_src = parser
             .static_pad("src")
-            .ok_or_else(|| ParserChainError("parser src pad".into()))?;
+            .ok_or_else(|| ParserChainError::ElementCreation("parser src pad".into()))?;
         parser_src
             .link(queue_sink_pad)
-            .map_err(|e| ParserChainError(format!("parser->queue: {e}")))?;
+            .map_err(|e| ParserChainError::LinkError(format!("parser->queue: {e}")))?;
     }
 
     parser
         .sync_state_with_parent()
-        .map_err(|_| ParserChainError("StateChangeFailed".into()))?;
+        .map_err(|_| ParserChainError::StateChangeFailed("parser sync_state_with_parent".into()))?;
 
     parser
         .static_pad("sink")
-        .ok_or_else(|| ParserChainError("parser sink pad missing".into()))
+        .ok_or_else(|| ParserChainError::ElementCreation("parser sink pad missing".into()))
 }

--- a/savant_gstreamer/savant_gstreamer/src/lib.rs
+++ b/savant_gstreamer/savant_gstreamer/src/lib.rs
@@ -1,8 +1,10 @@
+pub mod demux;
 pub mod id_meta;
 pub mod mp4_demuxer;
 pub mod mp4_muxer;
 pub mod pipeline;
 pub mod submit_gate;
+pub mod uri_demuxer;
 pub mod video_format;
 
 pub use video_format::VideoFormat;

--- a/savant_gstreamer/savant_gstreamer/src/mp4_demuxer.rs
+++ b/savant_gstreamer/savant_gstreamer/src/mp4_demuxer.rs
@@ -495,7 +495,11 @@ impl From<SampleError> for Mp4DemuxerError {
 
 impl From<ParserChainError> for Mp4DemuxerError {
     fn from(e: ParserChainError) -> Self {
-        Mp4DemuxerError::ElementCreation(e.0)
+        match e {
+            ParserChainError::ElementCreation(s) => Mp4DemuxerError::ElementCreation(s),
+            ParserChainError::LinkError(s) => Mp4DemuxerError::LinkError(s),
+            ParserChainError::StateChangeFailed(_) => Mp4DemuxerError::StateChangeFailed,
+        }
     }
 }
 

--- a/savant_gstreamer/savant_gstreamer/src/mp4_demuxer.rs
+++ b/savant_gstreamer/savant_gstreamer/src/mp4_demuxer.rs
@@ -29,30 +29,11 @@ use thiserror::Error;
 
 use savant_core::primitives::video_codec::VideoCodec;
 
-/// A single demuxed elementary stream packet.
-#[derive(Debug, Clone)]
-pub struct DemuxedPacket {
-    pub data: Vec<u8>,
-    pub pts_ns: u64,
-    pub dts_ns: Option<u64>,
-    pub duration_ns: Option<u64>,
-    pub is_keyframe: bool,
-}
-
-/// Video-stream metadata extracted from container caps at demux time.
-///
-/// Dimensions are the **encoded** width/height — QuickTime display-orientation
-/// metadata is NOT applied.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct VideoInfo {
-    pub codec: VideoCodec,
-    pub width: u32,
-    pub height: u32,
-    /// Framerate numerator. `0` if the container does not advertise a rate.
-    pub framerate_num: u32,
-    /// Framerate denominator. `1` if the container does not advertise a rate.
-    pub framerate_den: u32,
-}
+use crate::demux::helpers::{
+    build_parser_chain, sample_to_packet, signal_done, signal_info_done, ParserChainError,
+    SampleError,
+};
+pub use crate::demux::{DemuxedPacket, VideoInfo};
 
 /// Errors that can occur during demuxing.
 #[derive(Debug, Error)]
@@ -194,15 +175,22 @@ impl Mp4Demuxer {
         let info_pair = Arc::new((Mutex::new(false), Condvar::new()));
         let done_pair = Arc::new((Mutex::new(false), Condvar::new()));
 
+        // Adapter: the shared helpers emit only `VideoInfo`; the mp4 demuxer wraps
+        // that into `Mp4DemuxerOutput::StreamInfo`.
+        let emit_stream_info: Arc<dyn Fn(VideoInfo) + Send + Sync> = {
+            let on_output = on_output.clone();
+            Arc::new(move |info: VideoInfo| on_output(Mp4DemuxerOutput::StreamInfo(info)))
+        };
+
         // Dynamic pad linking (qtdemux -> parser? -> queue)
         let linked_video_pad = Arc::new(AtomicBool::new(false));
         let linked_video_pad_closure = linked_video_pad.clone();
         let pipeline_for_pad = pipeline.clone();
-        let on_output_pad = on_output.clone();
         let detected_codec_pad = detected_codec.clone();
         let video_info_pad = video_info.clone();
         let stream_info_fired_pad = stream_info_fired.clone();
         let info_pair_pad = info_pair.clone();
+        let emit_stream_info_pad = emit_stream_info.clone();
         demux.connect_pad_added(move |_demux, src_pad| {
             if linked_video_pad_closure.load(Ordering::SeqCst) {
                 return;
@@ -222,13 +210,13 @@ impl Mp4Demuxer {
                 return;
             }
 
-            maybe_emit_stream_info_from_caps(
+            crate::demux::helpers::maybe_emit_stream_info_from_caps(
                 caps.as_ref().map(|c| c.as_ref()),
                 &detected_codec_pad,
                 &video_info_pad,
                 &stream_info_fired_pad,
                 &info_pair_pad,
-                on_output_pad.as_ref(),
+                emit_stream_info_pad.as_ref(),
             );
 
             if queue_sink_pad.is_linked() {
@@ -263,6 +251,7 @@ impl Mp4Demuxer {
             let finished_sample = finished.clone();
             let info_pair_sample = info_pair.clone();
             let done_pair_sample = done_pair.clone();
+            let emit_stream_info_sample = emit_stream_info.clone();
 
             let on_output_eos = on_output.clone();
             let finished_eos = finished.clone();
@@ -282,7 +271,7 @@ impl Mp4Demuxer {
                             &video_info_sample,
                             &stream_info_fired_sample,
                             &info_pair_sample,
-                            on_output_sample.as_ref(),
+                            emit_stream_info_sample.as_ref(),
                         ) {
                             Ok(pkt) => {
                                 on_output_sample(Mp4DemuxerOutput::Packet(pkt));
@@ -290,7 +279,9 @@ impl Mp4Demuxer {
                             }
                             Err(e) => {
                                 if !finished_sample.swap(true, Ordering::SeqCst) {
-                                    on_output_sample(Mp4DemuxerOutput::Error(e));
+                                    on_output_sample(Mp4DemuxerOutput::Error(
+                                        Mp4DemuxerError::from(e),
+                                    ));
                                     signal_info_done(&info_pair_sample);
                                     signal_done(&done_pair_sample);
                                 }
@@ -492,239 +483,20 @@ impl Drop for Mp4Demuxer {
     }
 }
 
-/// Notify the condvar that the demuxer is done.
-fn signal_done(done_pair: &(Mutex<bool>, Condvar)) {
-    let (lock, cvar) = done_pair;
-    *lock.lock().unwrap() = true;
-    cvar.notify_all();
-}
-
-/// Notify the condvar that stream info is known or unavailable because the
-/// pipeline has already terminated.
-fn signal_info_done(info_pair: &(Mutex<bool>, Condvar)) {
-    let (lock, cvar) = info_pair;
-    *lock.lock().unwrap() = true;
-    cvar.notify_all();
-}
-
-/// Build [`VideoInfo`] from caps, when enough fields are available.
-fn video_info_from_caps(caps: &gst::CapsRef) -> Option<VideoInfo> {
-    let codec = codec_from_caps(caps)?;
-    let s = caps.structure(0)?;
-    let width = s
-        .get::<i32>("width")
-        .ok()
-        .and_then(|v| u32::try_from(v).ok())?;
-    let height = s
-        .get::<i32>("height")
-        .ok()
-        .and_then(|v| u32::try_from(v).ok())?;
-    let (framerate_num, framerate_den) = s
-        .get::<gst::Fraction>("framerate")
-        .ok()
-        .map(|f| (u32::try_from(f.numer()).ok(), u32::try_from(f.denom()).ok()))
-        .map(|(num, den)| (num.unwrap_or(0), den.unwrap_or(1)))
-        .unwrap_or((0, 1));
-    Some(VideoInfo {
-        codec,
-        width,
-        height,
-        framerate_num,
-        framerate_den,
-    })
-}
-
-/// Try to detect and emit stream info from caps exactly once.
-fn maybe_emit_stream_info_from_caps<F>(
-    caps: Option<&gst::CapsRef>,
-    detected_codec: &Mutex<Option<VideoCodec>>,
-    video_info: &Mutex<Option<VideoInfo>>,
-    stream_info_fired: &AtomicBool,
-    info_pair: &(Mutex<bool>, Condvar),
-    on_output: &F,
-) where
-    F: Fn(Mp4DemuxerOutput) + Send + Sync + ?Sized,
-{
-    let Some(caps) = caps else {
-        return;
-    };
-
-    let maybe_codec = codec_from_caps(caps);
-    if let Some(codec) = maybe_codec {
-        let mut detected_codec_guard = detected_codec.lock().unwrap();
-        if detected_codec_guard.is_none() {
-            *detected_codec_guard = Some(codec);
+impl From<SampleError> for Mp4DemuxerError {
+    fn from(e: SampleError) -> Self {
+        Mp4DemuxerError::PipelineError {
+            src: e.src,
+            msg: e.msg,
+            debug: e.debug,
         }
     }
-
-    let Some(info) = video_info_from_caps(caps) else {
-        return;
-    };
-
-    // Write `video_info` before flipping `stream_info_fired` so readers that
-    // take the fast path (`stream_info_fired.load()` -> `video_info()`) never
-    // observe the atomic set without the corresponding `video_info` value.
-    {
-        let mut guard = video_info.lock().unwrap();
-        if guard.is_some() {
-            return;
-        }
-        *guard = Some(info);
-    }
-
-    if stream_info_fired
-        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-        .is_ok()
-    {
-        signal_info_done(info_pair);
-        on_output(Mp4DemuxerOutput::StreamInfo(info));
-    }
 }
 
-/// Convert a GStreamer sample to a [`DemuxedPacket`], updating
-/// `detected_codec` on the first sample with caps.
-fn sample_to_packet<F>(
-    sample: gst::Sample,
-    detected_codec: &Mutex<Option<VideoCodec>>,
-    video_info: &Mutex<Option<VideoInfo>>,
-    stream_info_fired: &AtomicBool,
-    info_pair: &(Mutex<bool>, Condvar),
-    on_output: &F,
-) -> Result<DemuxedPacket, Mp4DemuxerError>
-where
-    F: Fn(Mp4DemuxerOutput) + Send + Sync + ?Sized,
-{
-    maybe_emit_stream_info_from_caps(
-        sample.caps(),
-        detected_codec,
-        video_info,
-        stream_info_fired,
-        info_pair,
-        on_output,
-    );
-
-    let Some(buffer) = sample.buffer() else {
-        return Err(Mp4DemuxerError::PipelineError {
-            src: "appsink".to_string(),
-            msg: "sample has no buffer".to_string(),
-            debug: String::new(),
-        });
-    };
-    let map = buffer
-        .map_readable()
-        .map_err(|e| Mp4DemuxerError::PipelineError {
-            src: "appsink".to_string(),
-            msg: format!("unable to map buffer: {e}"),
-            debug: String::new(),
-        })?;
-    let pts_ns = buffer.pts().map(|t| t.nseconds()).unwrap_or(0);
-    let dts_ns = buffer.dts().map(|t| t.nseconds());
-    let duration_ns = buffer.duration().map(|t| t.nseconds());
-    let is_keyframe = !buffer.flags().contains(gst::BufferFlags::DELTA_UNIT);
-    Ok(DemuxedPacket {
-        data: map.as_slice().to_vec(),
-        pts_ns,
-        dts_ns,
-        duration_ns,
-        is_keyframe,
-    })
-}
-
-/// Map GStreamer caps to a [`VideoCodec`] value.
-fn codec_from_caps(caps: &gst::CapsRef) -> Option<VideoCodec> {
-    let s = caps.structure(0)?;
-    match s.name().as_str() {
-        "video/x-h264" => Some(VideoCodec::H264),
-        "video/x-h265" => Some(VideoCodec::Hevc),
-        "video/x-av1" => Some(VideoCodec::Av1),
-        "video/x-vp8" => Some(VideoCodec::Vp8),
-        "video/x-vp9" => Some(VideoCodec::Vp9),
-        "image/jpeg" => Some(VideoCodec::Jpeg),
-        "image/png" => Some(VideoCodec::Png),
-        _ => None,
+impl From<ParserChainError> for Mp4DemuxerError {
+    fn from(e: ParserChainError) -> Self {
+        Mp4DemuxerError::ElementCreation(e.0)
     }
-}
-
-/// Dynamically insert a codec-specific parser (+ byte-stream capsfilter for
-/// H.264/HEVC) between the qtdemux pad and the queue.  Returns the parser's
-/// sink pad so the caller can link qtdemux's src_pad to it.
-fn build_parser_chain(
-    pipeline: &gst::Pipeline,
-    codec_name: Option<&str>,
-    queue_sink_pad: &gst::Pad,
-) -> Result<gst::Pad, Mp4DemuxerError> {
-    let (factory, needs_byte_stream_caps) = match codec_name {
-        Some("video/x-h264") => ("h264parse", true),
-        Some("video/x-h265") => ("h265parse", true),
-        Some("video/x-av1") => ("av1parse", false),
-        Some("video/x-vp8") => ("vp8parse", false),
-        Some("video/x-vp9") => ("vp9parse", false),
-        Some("image/jpeg") => ("jpegparse", false),
-        _ => return Err(Mp4DemuxerError::ElementCreation("no parser needed".into())),
-    };
-
-    let parser = gst::ElementFactory::make(factory)
-        .name("demux-parser")
-        .build()
-        .map_err(|e| Mp4DemuxerError::ElementCreation(format!("{factory}: {e}")))?;
-
-    if needs_byte_stream_caps {
-        parser.set_property("config-interval", -1i32);
-    }
-
-    pipeline
-        .add(&parser)
-        .map_err(|e| Mp4DemuxerError::LinkError(format!("add parser: {e}")))?;
-
-    if needs_byte_stream_caps {
-        let media = if factory == "h264parse" {
-            "video/x-h264"
-        } else {
-            "video/x-h265"
-        };
-        let caps = gst::Caps::builder(media)
-            .field("stream-format", "byte-stream")
-            .build();
-        let capsfilter = gst::ElementFactory::make("capsfilter")
-            .name("demux-parser-capsf")
-            .property("caps", &caps)
-            .build()
-            .map_err(|e| Mp4DemuxerError::ElementCreation(format!("capsfilter: {e}")))?;
-
-        pipeline
-            .add(&capsfilter)
-            .map_err(|e| Mp4DemuxerError::LinkError(format!("add capsfilter: {e}")))?;
-
-        parser
-            .link(&capsfilter)
-            .map_err(|e| Mp4DemuxerError::LinkError(format!("parser->capsfilter: {e}")))?;
-
-        let capsf_src = capsfilter
-            .static_pad("src")
-            .ok_or_else(|| Mp4DemuxerError::ElementCreation("capsfilter src pad".into()))?;
-        capsf_src
-            .link(queue_sink_pad)
-            .map_err(|e| Mp4DemuxerError::LinkError(format!("capsfilter->queue: {e}")))?;
-
-        capsfilter
-            .sync_state_with_parent()
-            .map_err(|_| Mp4DemuxerError::StateChangeFailed)?;
-    } else {
-        let parser_src = parser
-            .static_pad("src")
-            .ok_or_else(|| Mp4DemuxerError::ElementCreation("parser src pad".into()))?;
-        parser_src
-            .link(queue_sink_pad)
-            .map_err(|e| Mp4DemuxerError::LinkError(format!("parser->queue: {e}")))?;
-    }
-
-    parser
-        .sync_state_with_parent()
-        .map_err(|_| Mp4DemuxerError::StateChangeFailed)?;
-
-    parser
-        .static_pad("sink")
-        .ok_or_else(|| Mp4DemuxerError::ElementCreation("parser sink pad missing".into()))
 }
 
 #[cfg(test)]
@@ -758,6 +530,7 @@ mod tests {
 
     #[test]
     fn test_codec_from_caps_mapping() {
+        use crate::demux::helpers::codec_from_caps;
         let _ = gst::init();
         let h264 = gst::Caps::from_str("video/x-h264").unwrap();
         let hevc = gst::Caps::from_str("video/x-h265").unwrap();

--- a/savant_gstreamer/savant_gstreamer/src/uri_demuxer.rs
+++ b/savant_gstreamer/savant_gstreamer/src/uri_demuxer.rs
@@ -82,19 +82,37 @@ impl From<SampleError> for UriDemuxerError {
 
 impl From<ParserChainError> for UriDemuxerError {
     fn from(e: ParserChainError) -> Self {
-        UriDemuxerError::ElementCreation(e.0)
+        match e {
+            ParserChainError::ElementCreation(s) => UriDemuxerError::ElementCreation(s),
+            ParserChainError::LinkError(s) => UriDemuxerError::LinkError(s),
+            ParserChainError::StateChangeFailed(_) => UriDemuxerError::StateChangeFailed,
+        }
     }
 }
 
+/// Inserted byte-stream capsfilter wrapper.
+///
+/// Held by the caller so it can be torn down (unlink + Null + remove) if the
+/// subsequent attempt to link parsebin's src pad to `sink_pad` fails.  Without
+/// this the capsfilter would remain in the pipeline with its src linked to
+/// the queue and its sink dangling, permanently trapping the queue sink and
+/// stalling every later parsebin pad-added invocation.
+struct ByteStreamCapsfilter {
+    element: gst::Element,
+    sink_pad: gst::Pad,
+}
+
 /// Insert a byte-stream (Annex-B) capsfilter between parsebin's H.264/HEVC
-/// output and the queue. Returns `Ok(Some(capsfilter_sink_pad))` if the
-/// capsfilter was inserted, `Ok(None)` when the codec does not need one
-/// (passthrough to the queue), or `Err` on element creation/link failure.
+/// output and the queue. Returns `Ok(Some(_))` if the capsfilter was inserted
+/// (the caller links parsebin's src to `sink_pad`; on link failure it must
+/// call [`ByteStreamCapsfilter::remove_from`] to clean up), `Ok(None)` when
+/// the codec does not need one (passthrough to the queue), or `Err` on
+/// element creation / link failure.
 fn insert_byte_stream_capsfilter(
     pipeline: &gst::Pipeline,
     codec_name: Option<&str>,
     queue_sink_pad: &gst::Pad,
-) -> Result<Option<gst::Pad>, ParserChainError> {
+) -> Result<Option<ByteStreamCapsfilter>, ParserChainError> {
     let media = match codec_name {
         Some("video/x-h264") => "video/x-h264",
         Some("video/x-h265") => "video/x-h265",
@@ -108,35 +126,68 @@ fn insert_byte_stream_capsfilter(
         .name("uri-byte-stream-capsf")
         .property("caps", &caps)
         .build()
-        .map_err(|e| ParserChainError(format!("capsfilter: {e}")))?;
+        .map_err(|e| ParserChainError::ElementCreation(format!("capsfilter: {e}")))?;
 
     pipeline
         .add(&capsfilter)
-        .map_err(|e| ParserChainError(format!("add capsfilter: {e}")))?;
+        .map_err(|e| ParserChainError::LinkError(format!("add capsfilter: {e}")))?;
 
     let link_and_sync = (|| -> Result<gst::Pad, ParserChainError> {
         let capsf_src = capsfilter
             .static_pad("src")
-            .ok_or_else(|| ParserChainError("capsfilter src pad".into()))?;
+            .ok_or_else(|| ParserChainError::ElementCreation("capsfilter src pad".into()))?;
         capsf_src
             .link(queue_sink_pad)
-            .map_err(|e| ParserChainError(format!("capsfilter->queue: {e}")))?;
+            .map_err(|e| ParserChainError::LinkError(format!("capsfilter->queue: {e}")))?;
 
-        capsfilter
-            .sync_state_with_parent()
-            .map_err(|_| ParserChainError("StateChangeFailed".into()))?;
+        capsfilter.sync_state_with_parent().map_err(|_| {
+            ParserChainError::StateChangeFailed("capsfilter sync_state_with_parent".into())
+        })?;
 
         capsfilter
             .static_pad("sink")
-            .ok_or_else(|| ParserChainError("capsfilter sink pad missing".into()))
+            .ok_or_else(|| ParserChainError::ElementCreation("capsfilter sink pad missing".into()))
     })();
 
     match link_and_sync {
-        Ok(capsf_sink) => Ok(Some(capsf_sink)),
+        Ok(sink_pad) => Ok(Some(ByteStreamCapsfilter {
+            element: capsfilter,
+            sink_pad,
+        })),
         Err(e) => {
             let _ = capsfilter.set_state(gst::State::Null);
             let _ = pipeline.remove(&capsfilter);
             Err(e)
+        }
+    }
+}
+
+impl ByteStreamCapsfilter {
+    /// Tear down the capsfilter: unlink it from the queue, set it to `Null`,
+    /// and remove it from the pipeline.  Best-effort — every step is logged
+    /// but never bubbled up because this only runs on the failure path.
+    fn remove_from(self, pipeline: &gst::Pipeline) {
+        if let Some(src) = self.element.static_pad("src") {
+            if let Some(peer) = src.peer() {
+                if let Err(e) = src.unlink(&peer) {
+                    log::warn!(
+                        "UriDemuxer: failed to unlink orphan capsfilter src: {:?}",
+                        e
+                    );
+                }
+            }
+        }
+        if let Err(e) = self.element.set_state(gst::State::Null) {
+            log::warn!(
+                "UriDemuxer: failed to set orphan capsfilter to Null: {:?}",
+                e
+            );
+        }
+        if let Err(e) = pipeline.remove(&self.element) {
+            log::warn!(
+                "UriDemuxer: failed to remove orphan capsfilter from pipeline: {:?}",
+                e
+            );
         }
     }
 }
@@ -522,6 +573,9 @@ impl UriDemuxer {
         {
             let parsebin_weak = parsebin.downgrade();
             let on_output_uri_pad = on_output.clone();
+            let finished_uri_pad = finished.clone();
+            let info_pair_uri_pad = info_pair.clone();
+            let done_pair_uri_pad = done_pair.clone();
             urisrc.connect_pad_added(move |_uri_src, src_pad| {
                 let Some(parsebin) = parsebin_weak.upgrade() else {
                     return;
@@ -566,9 +620,18 @@ impl UriDemuxer {
                 }
 
                 if let Err(e) = src_pad.link(&parse_sink) {
-                    on_output_uri_pad(UriDemuxerOutput::Error(UriDemuxerError::LinkError(
-                        format!("urisourcebin->parsebin: {e}"),
-                    )));
+                    // Failing to attach the only video src pad to parsebin is
+                    // terminal: no further packets can ever flow.  Mirror the
+                    // sample-error / EOS / bus-error paths so any caller
+                    // blocked on `wait()` / `wait_for_video_info()` is
+                    // released instead of hanging until an external timeout.
+                    if !finished_uri_pad.swap(true, Ordering::SeqCst) {
+                        on_output_uri_pad(UriDemuxerOutput::Error(UriDemuxerError::LinkError(
+                            format!("urisourcebin->parsebin: {e}"),
+                        )));
+                        signal_info_done(&info_pair_uri_pad);
+                        signal_done(&done_pair_uri_pad);
+                    }
                 }
             });
         }
@@ -629,14 +692,14 @@ impl UriDemuxer {
                 // For `parsed=true` we only pin byte-stream output via a
                 // capsfilter. Adding another parser here would double-insert
                 // the SPS/PPS preamble.
-                let target_pad = if parsed {
+                let (target_pad, inserted_capsfilter) = if parsed {
                     match insert_byte_stream_capsfilter(
                         &pipeline_for_pad,
                         codec_name.as_deref(),
                         &queue_sink_pad_for_pad,
                     ) {
-                        Ok(Some(capsf_sink)) => capsf_sink,
-                        Ok(None) => queue_sink_pad_for_pad.clone(),
+                        Ok(Some(capsf)) => (capsf.sink_pad.clone(), Some(capsf)),
+                        Ok(None) => (queue_sink_pad_for_pad.clone(), None),
                         Err(e) => {
                             log::error!(
                                 "UriDemuxer: byte-stream capsfilter insertion failed: {:?}",
@@ -647,11 +710,36 @@ impl UriDemuxer {
                         }
                     }
                 } else {
-                    queue_sink_pad_for_pad.clone()
+                    (queue_sink_pad_for_pad.clone(), None)
                 };
 
-                if src_pad.link(&target_pad).is_ok() {
-                    linked_video_pad_closure.store(true, Ordering::SeqCst);
+                match src_pad.link(&target_pad) {
+                    Ok(_) => {
+                        linked_video_pad_closure.store(true, Ordering::SeqCst);
+                    }
+                    Err(e) => {
+                        // The capsfilter (if we inserted one) already linked
+                        // its src pad to the queue.  Leaving it in place would
+                        // make `queue_sink_pad.is_linked()` return `true` on
+                        // every later `pad-added`, short-circuiting all
+                        // subsequent attempts to attach a video pad and
+                        // permanently stalling packet flow.  Tear it down so
+                        // the queue sink becomes available again.
+                        if let Some(capsf) = inserted_capsfilter {
+                            capsf.remove_from(&pipeline_for_pad);
+                        }
+                        log::error!(
+                            "UriDemuxer: failed to link parsebin src pad {} → target: {:?}",
+                            src_pad.name(),
+                            e
+                        );
+                        on_output_parse_pad(UriDemuxerOutput::Error(UriDemuxerError::LinkError(
+                            format!(
+                                "parsebin->{}: {e}",
+                                if parsed { "capsfilter" } else { "queue" }
+                            ),
+                        )));
+                    }
                 }
             });
         }

--- a/savant_gstreamer/savant_gstreamer/src/uri_demuxer.rs
+++ b/savant_gstreamer/savant_gstreamer/src/uri_demuxer.rs
@@ -490,8 +490,7 @@ impl UriDemuxer {
             let source_properties = config.source_properties.clone();
             let on_output_ss = on_output.clone();
             urisrc.connect("source-setup", false, move |args| {
-                let Some(source) = args.get(1).and_then(|v| v.get::<gst::Element>().ok())
-                else {
+                let Some(source) = args.get(1).and_then(|v| v.get::<gst::Element>().ok()) else {
                     on_output_ss(UriDemuxerOutput::Error(UriDemuxerError::PipelineError {
                         src: "urisourcebin".into(),
                         msg: "source-setup signal: missing or invalid source element argument"
@@ -643,9 +642,7 @@ impl UriDemuxer {
                                 "UriDemuxer: byte-stream capsfilter insertion failed: {:?}",
                                 e
                             );
-                            on_output_parse_pad(UriDemuxerOutput::Error(
-                                UriDemuxerError::from(e),
-                            ));
+                            on_output_parse_pad(UriDemuxerOutput::Error(UriDemuxerError::from(e)));
                             return;
                         }
                     }

--- a/savant_gstreamer/savant_gstreamer/src/uri_demuxer.rs
+++ b/savant_gstreamer/savant_gstreamer/src/uri_demuxer.rs
@@ -66,8 +66,6 @@ pub enum UriDemuxerError {
         name: String,
         error: String,
     },
-    #[error("Demuxer already finished")]
-    AlreadyFinished,
 }
 
 impl From<SampleError> for UriDemuxerError {

--- a/savant_gstreamer/savant_gstreamer/src/uri_demuxer.rs
+++ b/savant_gstreamer/savant_gstreamer/src/uri_demuxer.rs
@@ -648,6 +648,9 @@ impl UriDemuxer {
             let info_pair_pad = info_pair.clone();
             let emit_stream_info_pad = emit_stream_info.clone();
             let on_output_parse_pad = on_output.clone();
+            let finished_parse_pad = finished.clone();
+            let info_pair_parse_pad_done = info_pair.clone();
+            let done_pair_parse_pad = done_pair.clone();
             let parsed = config.parsed;
             parsebin.connect_pad_added(move |_parsebin, src_pad| {
                 if linked_video_pad_closure.load(Ordering::SeqCst) {
@@ -705,7 +708,19 @@ impl UriDemuxer {
                                 "UriDemuxer: byte-stream capsfilter insertion failed: {:?}",
                                 e
                             );
-                            on_output_parse_pad(UriDemuxerOutput::Error(UriDemuxerError::from(e)));
+                            // Failing to attach the only video pad is
+                            // terminal — packets can never flow.  Mirror the
+                            // sample-error / EOS / bus-error paths so any
+                            // caller blocked on `wait()` /
+                            // `wait_for_video_info()` is released instead of
+                            // hanging until an external timeout.
+                            if !finished_parse_pad.swap(true, Ordering::SeqCst) {
+                                on_output_parse_pad(UriDemuxerOutput::Error(
+                                    UriDemuxerError::from(e),
+                                ));
+                                signal_info_done(&info_pair_parse_pad_done);
+                                signal_done(&done_pair_parse_pad);
+                            }
                             return;
                         }
                     }
@@ -733,12 +748,18 @@ impl UriDemuxer {
                             src_pad.name(),
                             e
                         );
-                        on_output_parse_pad(UriDemuxerOutput::Error(UriDemuxerError::LinkError(
-                            format!(
-                                "parsebin->{}: {e}",
-                                if parsed { "capsfilter" } else { "queue" }
-                            ),
-                        )));
+                        // Same terminal-path treatment as the capsfilter
+                        // insertion failure above: release any waiters.
+                        if !finished_parse_pad.swap(true, Ordering::SeqCst) {
+                            on_output_parse_pad(UriDemuxerOutput::Error(
+                                UriDemuxerError::LinkError(format!(
+                                    "parsebin->{}: {e}",
+                                    if parsed { "capsfilter" } else { "queue" }
+                                )),
+                            ));
+                            signal_info_done(&info_pair_parse_pad_done);
+                            signal_done(&done_pair_parse_pad);
+                        }
                     }
                 }
             });

--- a/savant_gstreamer/savant_gstreamer/src/uri_demuxer.rs
+++ b/savant_gstreamer/savant_gstreamer/src/uri_demuxer.rs
@@ -114,21 +114,31 @@ fn insert_byte_stream_capsfilter(
         .add(&capsfilter)
         .map_err(|e| ParserChainError(format!("add capsfilter: {e}")))?;
 
-    let capsf_src = capsfilter
-        .static_pad("src")
-        .ok_or_else(|| ParserChainError("capsfilter src pad".into()))?;
-    capsf_src
-        .link(queue_sink_pad)
-        .map_err(|e| ParserChainError(format!("capsfilter->queue: {e}")))?;
+    let link_and_sync = (|| -> Result<gst::Pad, ParserChainError> {
+        let capsf_src = capsfilter
+            .static_pad("src")
+            .ok_or_else(|| ParserChainError("capsfilter src pad".into()))?;
+        capsf_src
+            .link(queue_sink_pad)
+            .map_err(|e| ParserChainError(format!("capsfilter->queue: {e}")))?;
 
-    capsfilter
-        .sync_state_with_parent()
-        .map_err(|_| ParserChainError("StateChangeFailed".into()))?;
+        capsfilter
+            .sync_state_with_parent()
+            .map_err(|_| ParserChainError("StateChangeFailed".into()))?;
 
-    let capsf_sink = capsfilter
-        .static_pad("sink")
-        .ok_or_else(|| ParserChainError("capsfilter sink pad missing".into()))?;
-    Ok(Some(capsf_sink))
+        capsfilter
+            .static_pad("sink")
+            .ok_or_else(|| ParserChainError("capsfilter sink pad missing".into()))
+    })();
+
+    match link_and_sync {
+        Ok(capsf_sink) => Ok(Some(capsf_sink)),
+        Err(e) => {
+            let _ = capsfilter.set_state(gst::State::Null);
+            let _ = pipeline.remove(&capsfilter);
+            Err(e)
+        }
+    }
 }
 
 /// Very cheap syntactic URI check: requires a leading scheme and `://`.
@@ -136,14 +146,16 @@ fn insert_byte_stream_capsfilter(
 /// This only rejects obviously malformed values up front; GStreamer does the
 /// real validation at state-change time.
 fn is_plausible_uri(uri: &str) -> bool {
-    let trimmed = uri.trim();
-    let Some(scheme_end) = trimmed.find("://") else {
+    let Some(scheme_end) = uri.find("://") else {
         return false;
     };
     if scheme_end == 0 {
         return false;
     }
-    let scheme = &trimmed[..scheme_end];
+    if uri.len() <= scheme_end + 3 {
+        return false;
+    }
+    let scheme = &uri[..scheme_end];
     scheme
         .chars()
         .all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '-' || c == '.')
@@ -371,15 +383,16 @@ impl UriDemuxer {
     {
         let _ = gst::init();
 
-        if config.uri.trim().is_empty() {
+        let uri = config.uri.trim().to_string();
+        if uri.is_empty() {
             return Err(UriDemuxerError::MissingUri);
         }
 
         // Validate the URI string: require a scheme separator. GStreamer itself
         // validates more strictly during state change, but we reject obviously
         // malformed values up front so the caller gets a typed error.
-        if !is_plausible_uri(&config.uri) {
-            return Err(UriDemuxerError::InvalidUri(config.uri.clone()));
+        if !is_plausible_uri(&uri) {
+            return Err(UriDemuxerError::InvalidUri(uri));
         }
 
         let pipeline = gst::Pipeline::new();
@@ -388,7 +401,7 @@ impl UriDemuxer {
             .name("uri-src")
             .build()
             .map_err(|e| UriDemuxerError::ElementCreation(format!("urisourcebin: {e}")))?;
-        urisrc.set_property("uri", &config.uri);
+        urisrc.set_property("uri", &uri);
 
         // Apply user-supplied bin properties.
         for (name, value) in &config.bin_properties {
@@ -477,10 +490,16 @@ impl UriDemuxer {
             let source_properties = config.source_properties.clone();
             let on_output_ss = on_output.clone();
             urisrc.connect("source-setup", false, move |args| {
-                let source = args
-                    .get(1)
-                    .and_then(|v| v.get::<gst::Element>().ok())
-                    .expect("source-setup provides the source element");
+                let Some(source) = args.get(1).and_then(|v| v.get::<gst::Element>().ok())
+                else {
+                    on_output_ss(UriDemuxerOutput::Error(UriDemuxerError::PipelineError {
+                        src: "urisourcebin".into(),
+                        msg: "source-setup signal: missing or invalid source element argument"
+                            .into(),
+                        debug: String::new(),
+                    }));
+                    return None;
+                };
                 let factory_name = source
                     .factory()
                     .map(|f| f.name().to_string())
@@ -566,6 +585,7 @@ impl UriDemuxer {
             let stream_info_fired_pad = stream_info_fired.clone();
             let info_pair_pad = info_pair.clone();
             let emit_stream_info_pad = emit_stream_info.clone();
+            let on_output_parse_pad = on_output.clone();
             let parsed = config.parsed;
             parsebin.connect_pad_added(move |_parsebin, src_pad| {
                 if linked_video_pad_closure.load(Ordering::SeqCst) {
@@ -618,7 +638,16 @@ impl UriDemuxer {
                     ) {
                         Ok(Some(capsf_sink)) => capsf_sink,
                         Ok(None) => queue_sink_pad_for_pad.clone(),
-                        Err(_) => queue_sink_pad_for_pad.clone(),
+                        Err(e) => {
+                            log::error!(
+                                "UriDemuxer: byte-stream capsfilter insertion failed: {:?}",
+                                e
+                            );
+                            on_output_parse_pad(UriDemuxerOutput::Error(
+                                UriDemuxerError::from(e),
+                            ));
+                            return;
+                        }
                     }
                 } else {
                     queue_sink_pad_for_pad.clone()

--- a/savant_gstreamer/savant_gstreamer/src/uri_demuxer.rs
+++ b/savant_gstreamer/savant_gstreamer/src/uri_demuxer.rs
@@ -512,9 +512,41 @@ impl UriDemuxer {
                     return;
                 };
                 if parse_sink.is_linked() {
-                    // More than one stream from urisourcebin; parsebin already handles one.
                     return;
                 }
+
+                // For multi-stream sources (e.g. RTSP, MKV, TS, DASH),
+                // urisourcebin emits separate pads per stream.  Only link
+                // video-like pads so that a non-video pad (audio, subtitle,
+                // data) arriving first does not steal the single parsebin
+                // sink slot and cause the video stream to be dropped.
+                let is_video = src_pad
+                    .current_caps()
+                    .or_else(|| Some(src_pad.query_caps(None)))
+                    .and_then(|caps| {
+                        caps.structure(0).map(|s| {
+                            let name = s.name();
+                            if name.starts_with("video/") || name.starts_with("image/") {
+                                return true;
+                            }
+                            if name == "application/x-rtp" {
+                                if let Ok(media) = s.get::<&str>("media") {
+                                    return media == "video";
+                                }
+                            }
+                            false
+                        })
+                    })
+                    .unwrap_or(false);
+
+                if !is_video {
+                    log::debug!(
+                        "UriDemuxer: skipping non-video urisourcebin pad {}",
+                        src_pad.name()
+                    );
+                    return;
+                }
+
                 if let Err(e) = src_pad.link(&parse_sink) {
                     on_output_uri_pad(UriDemuxerOutput::Error(UriDemuxerError::LinkError(
                         format!("urisourcebin->parsebin: {e}"),

--- a/savant_gstreamer/savant_gstreamer/src/uri_demuxer.rs
+++ b/savant_gstreamer/savant_gstreamer/src/uri_demuxer.rs
@@ -1,0 +1,955 @@
+//! Callback-based GStreamer URI demuxer: `urisourcebin -> parsebin -> [capsfilter] -> queue -> appsink`.
+//!
+//! Reads encoded packets from any GStreamer-supported URI (`file://`, `http(s)://`,
+//! `rtsp://`, HLS, DASH, MKV, TS, MP4 ...) and delivers them as elementary-stream
+//! payloads with timestamps through a user-supplied callback. Does **not**
+//! decode.
+//!
+//! API-compatible with [`crate::mp4_demuxer::Mp4Demuxer`] — it emits the same
+//! [`DemuxedPacket`] / [`VideoInfo`] types and exposes the same wait / finish
+//! surface.
+//!
+//! # Pipeline
+//!
+//! ```text
+//! urisourcebin (uri + bin_properties)
+//!   -- source-setup --> inner src element (apply source_properties)
+//!   -- pad-added    --> parsebin
+//!                         -- pad-added --> [byte-stream capsfilter if parsed=true]
+//!                                            --> queue --> appsink
+//! ```
+//!
+//! # Threading
+//!
+//! The callback is invoked from GStreamer's streaming thread. Do **not** call
+//! [`UriDemuxer::finish`] from within the callback — that would deadlock.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+use std::time::Duration;
+
+use gstreamer as gst;
+use gstreamer::glib;
+use gstreamer::prelude::*;
+use gstreamer_app as gst_app;
+use thiserror::Error;
+
+use savant_core::primitives::video_codec::VideoCodec;
+
+use crate::demux::helpers::{
+    sample_to_packet, signal_done, signal_info_done, ParserChainError, SampleError,
+};
+pub use crate::demux::{DemuxedPacket, VideoInfo};
+
+/// Errors that can occur while constructing or running a [`UriDemuxer`].
+#[derive(Debug, Error)]
+pub enum UriDemuxerError {
+    #[error("URI is missing or empty")]
+    MissingUri,
+    #[error("Invalid URI: {0}")]
+    InvalidUri(String),
+    #[error("Failed to create GStreamer element: {0}")]
+    ElementCreation(String),
+    #[error("Failed to link elements: {0}")]
+    LinkError(String),
+    #[error("Pipeline state change failed")]
+    StateChangeFailed,
+    #[error("Pipeline error from {src}: {msg} ({debug})")]
+    PipelineError {
+        src: String,
+        msg: String,
+        debug: String,
+    },
+    #[error("Failed to set property '{name}' on '{element}': {error}")]
+    PropertyError {
+        element: String,
+        name: String,
+        error: String,
+    },
+    #[error("Demuxer already finished")]
+    AlreadyFinished,
+}
+
+impl From<SampleError> for UriDemuxerError {
+    fn from(e: SampleError) -> Self {
+        UriDemuxerError::PipelineError {
+            src: e.src,
+            msg: e.msg,
+            debug: e.debug,
+        }
+    }
+}
+
+impl From<ParserChainError> for UriDemuxerError {
+    fn from(e: ParserChainError) -> Self {
+        UriDemuxerError::ElementCreation(e.0)
+    }
+}
+
+/// Insert a byte-stream (Annex-B) capsfilter between parsebin's H.264/HEVC
+/// output and the queue. Returns `Ok(Some(capsfilter_sink_pad))` if the
+/// capsfilter was inserted, `Ok(None)` when the codec does not need one
+/// (passthrough to the queue), or `Err` on element creation/link failure.
+fn insert_byte_stream_capsfilter(
+    pipeline: &gst::Pipeline,
+    codec_name: Option<&str>,
+    queue_sink_pad: &gst::Pad,
+) -> Result<Option<gst::Pad>, ParserChainError> {
+    let media = match codec_name {
+        Some("video/x-h264") => "video/x-h264",
+        Some("video/x-h265") => "video/x-h265",
+        _ => return Ok(None),
+    };
+
+    let caps = gst::Caps::builder(media)
+        .field("stream-format", "byte-stream")
+        .build();
+    let capsfilter = gst::ElementFactory::make("capsfilter")
+        .name("uri-byte-stream-capsf")
+        .property("caps", &caps)
+        .build()
+        .map_err(|e| ParserChainError(format!("capsfilter: {e}")))?;
+
+    pipeline
+        .add(&capsfilter)
+        .map_err(|e| ParserChainError(format!("add capsfilter: {e}")))?;
+
+    let capsf_src = capsfilter
+        .static_pad("src")
+        .ok_or_else(|| ParserChainError("capsfilter src pad".into()))?;
+    capsf_src
+        .link(queue_sink_pad)
+        .map_err(|e| ParserChainError(format!("capsfilter->queue: {e}")))?;
+
+    capsfilter
+        .sync_state_with_parent()
+        .map_err(|_| ParserChainError("StateChangeFailed".into()))?;
+
+    let capsf_sink = capsfilter
+        .static_pad("sink")
+        .ok_or_else(|| ParserChainError("capsfilter sink pad missing".into()))?;
+    Ok(Some(capsf_sink))
+}
+
+/// Very cheap syntactic URI check: requires a leading scheme and `://`.
+///
+/// This only rejects obviously malformed values up front; GStreamer does the
+/// real validation at state-change time.
+fn is_plausible_uri(uri: &str) -> bool {
+    let trimmed = uri.trim();
+    let Some(scheme_end) = trimmed.find("://") else {
+        return false;
+    };
+    if scheme_end == 0 {
+        return false;
+    }
+    let scheme = &trimmed[..scheme_end];
+    scheme
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '-' || c == '.')
+        && scheme
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_alphabetic())
+}
+
+/// Callback payload delivered by [`UriDemuxer`].
+#[derive(Debug)]
+pub enum UriDemuxerOutput {
+    /// Fires exactly once, before the first `Packet`. May be absent if the
+    /// pipeline errors before caps are known.
+    StreamInfo(VideoInfo),
+    /// A demuxed packet from the container.
+    Packet(DemuxedPacket),
+    /// End of stream — all packets have been delivered.
+    Eos,
+    /// An error occurred in the pipeline.
+    Error(UriDemuxerError),
+}
+
+/// A scalar property value accepted by [`UriDemuxerConfig`].
+///
+/// GStreamer's GObject type system will auto-convert `I64` / `U64` / `F64`
+/// to the target property's concrete type (`u32`, `i32`, etc.). Use [`Bytes`]
+/// for binary blobs.
+#[derive(Debug, Clone)]
+pub enum PropertyValue {
+    Bool(bool),
+    I64(i64),
+    U64(u64),
+    F64(f64),
+    String(String),
+    Bytes(Vec<u8>),
+}
+
+impl PropertyValue {
+    fn to_glib_value(&self) -> glib::Value {
+        match self {
+            PropertyValue::Bool(v) => v.to_value(),
+            PropertyValue::I64(v) => v.to_value(),
+            PropertyValue::U64(v) => v.to_value(),
+            PropertyValue::F64(v) => v.to_value(),
+            PropertyValue::String(v) => v.to_value(),
+            PropertyValue::Bytes(v) => glib::Bytes::from(v.as_slice()).to_value(),
+        }
+    }
+}
+
+/// Apply a [`PropertyValue`] to a GObject property, coercing the numeric
+/// GType to match the target property's declared type (`gint`, `guint`,
+/// `gint64`, `guint64`, `gfloat`, `gdouble`, ...).
+///
+/// GStreamer's `set_property_from_value` requires an exact GType match, so
+/// a Python `int` wrapped as `gint64` can't be assigned to a `gint`
+/// property (e.g. `urisourcebin::buffer-size`). We query the target's
+/// `ParamSpec` and use `Value::transform_with_type` to bridge scalar
+/// integer / float types. Non-scalar types (strings, boxed bytes) pass
+/// through unchanged.
+fn apply_property(obj: &glib::Object, name: &str, value: &PropertyValue) -> Result<(), String> {
+    let gvalue = value.to_glib_value();
+    let target_type = match obj.find_property(name) {
+        Some(pspec) => pspec.value_type(),
+        None => return Err("no such property".into()),
+    };
+
+    // Exact match: no transform needed.
+    let coerced = if gvalue.type_() == target_type {
+        gvalue
+    } else {
+        match gvalue.transform_with_type(target_type) {
+            Ok(v) => v,
+            Err(_) => {
+                return Err(format!(
+                    "type mismatch: cannot convert {} to {}",
+                    gvalue.type_().name(),
+                    target_type.name()
+                ));
+            }
+        }
+    };
+
+    let obj_clone = obj.clone();
+    let name_owned = name.to_string();
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        obj_clone.set_property_from_value(&name_owned, &coerced);
+    }));
+    if result.is_err() {
+        return Err("set_property_from_value panicked".into());
+    }
+    Ok(())
+}
+
+impl From<bool> for PropertyValue {
+    fn from(v: bool) -> Self {
+        PropertyValue::Bool(v)
+    }
+}
+impl From<i32> for PropertyValue {
+    fn from(v: i32) -> Self {
+        PropertyValue::I64(v as i64)
+    }
+}
+impl From<i64> for PropertyValue {
+    fn from(v: i64) -> Self {
+        PropertyValue::I64(v)
+    }
+}
+impl From<u32> for PropertyValue {
+    fn from(v: u32) -> Self {
+        PropertyValue::U64(v as u64)
+    }
+}
+impl From<u64> for PropertyValue {
+    fn from(v: u64) -> Self {
+        PropertyValue::U64(v)
+    }
+}
+impl From<f32> for PropertyValue {
+    fn from(v: f32) -> Self {
+        PropertyValue::F64(v as f64)
+    }
+}
+impl From<f64> for PropertyValue {
+    fn from(v: f64) -> Self {
+        PropertyValue::F64(v)
+    }
+}
+impl From<&str> for PropertyValue {
+    fn from(v: &str) -> Self {
+        PropertyValue::String(v.to_string())
+    }
+}
+impl From<String> for PropertyValue {
+    fn from(v: String) -> Self {
+        PropertyValue::String(v)
+    }
+}
+impl From<Vec<u8>> for PropertyValue {
+    fn from(v: Vec<u8>) -> Self {
+        PropertyValue::Bytes(v)
+    }
+}
+
+/// Configuration for a [`UriDemuxer`].
+///
+/// Only [`uri`](Self::uri) is mandatory. Everything else is optional:
+///
+/// - `parsed` defaults to `true` and inserts a byte-stream (Annex-B) capsfilter
+///   after parsebin's H.264/HEVC pad. Set to `false` to pass parsebin output
+///   through unchanged.
+/// - `bin_properties` are applied to `urisourcebin` itself (e.g. `buffer-size`,
+///   `use-buffering`, `connection-speed`).
+/// - `source_properties` are applied to the dynamically-created inner source
+///   element (e.g. `rtspsrc`'s `latency` / `user-id` / `user-pw` / `protocols`,
+///   `souphttpsrc`'s `user-agent` / `extra-headers`). They are applied via the
+///   `source-setup` signal; see GStreamer's urisourcebin documentation.
+pub struct UriDemuxerConfig {
+    pub uri: String,
+    pub parsed: bool,
+    pub bin_properties: Vec<(String, PropertyValue)>,
+    pub source_properties: Vec<(String, PropertyValue)>,
+}
+
+impl UriDemuxerConfig {
+    /// Create a new config for the given URI.
+    pub fn new(uri: impl Into<String>) -> Self {
+        Self {
+            uri: uri.into(),
+            parsed: true,
+            bin_properties: Vec::new(),
+            source_properties: Vec::new(),
+        }
+    }
+
+    /// Set the `parsed` flag.
+    pub fn with_parsed(mut self, parsed: bool) -> Self {
+        self.parsed = parsed;
+        self
+    }
+
+    /// Set a property on the `urisourcebin` element.
+    pub fn with_bin_property<V: Into<PropertyValue>>(mut self, name: &str, value: V) -> Self {
+        self.bin_properties.push((name.to_string(), value.into()));
+        self
+    }
+
+    /// Set a property on the inner source element (via `source-setup`).
+    pub fn with_source_property<V: Into<PropertyValue>>(mut self, name: &str, value: V) -> Self {
+        self.source_properties
+            .push((name.to_string(), value.into()));
+        self
+    }
+}
+
+/// Callback-based GStreamer URI demuxer.
+///
+/// Reads encoded packets from any GStreamer-supported URI and delivers them
+/// through the `on_output` callback provided at construction.
+///
+/// # Threading
+///
+/// The callback fires on GStreamer's internal streaming thread. Do **not**
+/// call [`finish`](Self::finish) from within the callback.
+pub struct UriDemuxer {
+    pipeline: gst::Pipeline,
+    finished: Arc<AtomicBool>,
+    detected_codec: Arc<Mutex<Option<VideoCodec>>>,
+    video_info: Arc<Mutex<Option<VideoInfo>>>,
+    info_pair: Arc<(Mutex<bool>, Condvar)>,
+    stream_info_fired: Arc<AtomicBool>,
+    done_pair: Arc<(Mutex<bool>, Condvar)>,
+}
+
+impl UriDemuxer {
+    /// Create a new demuxer from a [`UriDemuxerConfig`].
+    ///
+    /// The pipeline starts immediately; packets are delivered through
+    /// `on_output` on GStreamer's streaming thread.
+    pub fn new<F>(config: UriDemuxerConfig, on_output: F) -> Result<Self, UriDemuxerError>
+    where
+        F: Fn(UriDemuxerOutput) + Send + Sync + 'static,
+    {
+        let _ = gst::init();
+
+        if config.uri.trim().is_empty() {
+            return Err(UriDemuxerError::MissingUri);
+        }
+
+        // Validate the URI string: require a scheme separator. GStreamer itself
+        // validates more strictly during state change, but we reject obviously
+        // malformed values up front so the caller gets a typed error.
+        if !is_plausible_uri(&config.uri) {
+            return Err(UriDemuxerError::InvalidUri(config.uri.clone()));
+        }
+
+        let pipeline = gst::Pipeline::new();
+
+        let urisrc = gst::ElementFactory::make("urisourcebin")
+            .name("uri-src")
+            .build()
+            .map_err(|e| UriDemuxerError::ElementCreation(format!("urisourcebin: {e}")))?;
+        urisrc.set_property("uri", &config.uri);
+
+        // Apply user-supplied bin properties.
+        for (name, value) in &config.bin_properties {
+            if let Err(err) = apply_property(urisrc.upcast_ref::<glib::Object>(), name, value) {
+                return Err(UriDemuxerError::PropertyError {
+                    element: "urisourcebin".into(),
+                    name: name.clone(),
+                    error: err,
+                });
+            }
+        }
+
+        let parsebin = gst::ElementFactory::make("parsebin")
+            .name("uri-parse")
+            .build()
+            .map_err(|e| UriDemuxerError::ElementCreation(format!("parsebin: {e}")))?;
+
+        // parsebin autoplugs h264parse/h265parse internally with a default
+        // `config-interval=-1` that inserts SPS/PPS before every keyframe.
+        // We add our own downstream `h264parse`/`h265parse` (same as
+        // `Mp4Demuxer`) with `config-interval=-1` to pin byte-stream output.
+        // Having both parsers insert SPS/PPS would double the preamble, so
+        // set parsebin's internal parser to `config-interval=0` (no in-band
+        // insertion) and rely on the downstream parser for single insertion.
+        // Match Mp4Demuxer: parsebin's internal h264parse/h265parse handle
+        // SPS/PPS insertion (`config-interval=-1`) once per keyframe. We do
+        // *not* add another parser downstream to avoid a double insertion.
+        if let Some(parse_bin) = parsebin.dynamic_cast_ref::<gst::Bin>() {
+            parse_bin.connect_deep_element_added(|_bin, _sub_bin, elem| {
+                if let Some(factory) = elem.factory() {
+                    let name = factory.name();
+                    if (name == "h264parse" || name == "h265parse")
+                        && elem.has_property("config-interval")
+                    {
+                        elem.set_property("config-interval", -1i32);
+                    }
+                }
+            });
+        }
+
+        let queue = gst::ElementFactory::make("queue")
+            .name("demux-queue")
+            .build()
+            .map_err(|e| UriDemuxerError::ElementCreation(format!("queue: {e}")))?;
+
+        let sink_elem = gst::ElementFactory::make("appsink")
+            .name("demux-sink")
+            .build()
+            .map_err(|e| UriDemuxerError::ElementCreation(format!("appsink: {e}")))?;
+        sink_elem.set_property("sync", false);
+        sink_elem.set_property("emit-signals", false);
+        sink_elem.set_property("max-buffers", 64u32);
+        sink_elem.set_property("drop", false);
+
+        pipeline
+            .add_many([&urisrc, &parsebin, &queue, &sink_elem])
+            .map_err(|e| UriDemuxerError::LinkError(format!("add_many: {e}")))?;
+
+        queue
+            .link(&sink_elem)
+            .map_err(|e| UriDemuxerError::LinkError(format!("queue->appsink: {e}")))?;
+
+        let queue_sink_pad = queue
+            .static_pad("sink")
+            .ok_or_else(|| UriDemuxerError::ElementCreation("queue sink pad missing".into()))?;
+
+        // Shared state
+        let on_output = Arc::new(on_output);
+        let detected_codec: Arc<Mutex<Option<VideoCodec>>> = Arc::new(Mutex::new(None));
+        let video_info: Arc<Mutex<Option<VideoInfo>>> = Arc::new(Mutex::new(None));
+        let stream_info_fired = Arc::new(AtomicBool::new(false));
+        let finished = Arc::new(AtomicBool::new(false));
+        let info_pair = Arc::new((Mutex::new(false), Condvar::new()));
+        let done_pair = Arc::new((Mutex::new(false), Condvar::new()));
+
+        // Adapter: the shared helpers emit only `VideoInfo`; wrap into our variant.
+        let emit_stream_info: Arc<dyn Fn(VideoInfo) + Send + Sync> = {
+            let on_output = on_output.clone();
+            Arc::new(move |info: VideoInfo| on_output(UriDemuxerOutput::StreamInfo(info)))
+        };
+
+        // source-setup: apply per-source properties once the inner src element is
+        // created. This works for any source type urisourcebin autoplugs
+        // (filesrc, souphttpsrc, rtspsrc, hlsdemux's underlying http src, ...).
+        {
+            let source_properties = config.source_properties.clone();
+            let on_output_ss = on_output.clone();
+            urisrc.connect("source-setup", false, move |args| {
+                let source = args
+                    .get(1)
+                    .and_then(|v| v.get::<gst::Element>().ok())
+                    .expect("source-setup provides the source element");
+                let factory_name = source
+                    .factory()
+                    .map(|f| f.name().to_string())
+                    .unwrap_or_else(|| "<unknown>".into());
+                for (name, value) in &source_properties {
+                    if let Err(err) =
+                        apply_property(source.upcast_ref::<glib::Object>(), name, value)
+                    {
+                        on_output_ss(UriDemuxerOutput::Error(UriDemuxerError::PropertyError {
+                            element: factory_name.clone(),
+                            name: name.clone(),
+                            error: err,
+                        }));
+                    }
+                }
+                None
+            });
+        }
+
+        // urisourcebin::pad-added → link src pad to parsebin.sink
+        {
+            let parsebin_weak = parsebin.downgrade();
+            let on_output_uri_pad = on_output.clone();
+            urisrc.connect_pad_added(move |_uri_src, src_pad| {
+                let Some(parsebin) = parsebin_weak.upgrade() else {
+                    return;
+                };
+                let Some(parse_sink) = parsebin.static_pad("sink") else {
+                    return;
+                };
+                if parse_sink.is_linked() {
+                    // More than one stream from urisourcebin; parsebin already handles one.
+                    return;
+                }
+                if let Err(e) = src_pad.link(&parse_sink) {
+                    on_output_uri_pad(UriDemuxerOutput::Error(UriDemuxerError::LinkError(
+                        format!("urisourcebin->parsebin: {e}"),
+                    )));
+                }
+            });
+        }
+
+        // parsebin::pad-added → choose first video/image pad, link [capsfilter?] → queue
+        {
+            let linked_video_pad = Arc::new(AtomicBool::new(false));
+            let linked_video_pad_closure = linked_video_pad.clone();
+            let pipeline_for_pad = pipeline.clone();
+            let queue_sink_pad_for_pad = queue_sink_pad.clone();
+            let detected_codec_pad = detected_codec.clone();
+            let video_info_pad = video_info.clone();
+            let stream_info_fired_pad = stream_info_fired.clone();
+            let info_pair_pad = info_pair.clone();
+            let emit_stream_info_pad = emit_stream_info.clone();
+            let parsed = config.parsed;
+            parsebin.connect_pad_added(move |_parsebin, src_pad| {
+                if linked_video_pad_closure.load(Ordering::SeqCst) {
+                    // Already accepted a video pad; drop additional streams.
+                    log::debug!("UriDemuxer: ignoring extra parsebin pad {}", src_pad.name());
+                    return;
+                }
+
+                let caps = src_pad
+                    .current_caps()
+                    .or_else(|| Some(src_pad.query_caps(None)));
+                let codec_name = caps
+                    .as_ref()
+                    .and_then(|c| c.structure(0).map(|s| s.name().to_string()));
+
+                let is_video = codec_name
+                    .as_deref()
+                    .is_some_and(|n| n.starts_with("video/") || n.starts_with("image/"));
+                if !is_video {
+                    log::debug!(
+                        "UriDemuxer: ignoring non-video parsebin pad with caps {:?}",
+                        codec_name
+                    );
+                    return;
+                }
+
+                crate::demux::helpers::maybe_emit_stream_info_from_caps(
+                    caps.as_ref().map(|c| c.as_ref()),
+                    &detected_codec_pad,
+                    &video_info_pad,
+                    &stream_info_fired_pad,
+                    &info_pair_pad,
+                    emit_stream_info_pad.as_ref(),
+                );
+
+                if queue_sink_pad_for_pad.is_linked() {
+                    return;
+                }
+
+                // parsebin already parses and inserts SPS/PPS at every IDR
+                // (via its internal h264parse/h265parse with `config-interval=-1`).
+                // For `parsed=true` we only pin byte-stream output via a
+                // capsfilter. Adding another parser here would double-insert
+                // the SPS/PPS preamble.
+                let target_pad = if parsed {
+                    match insert_byte_stream_capsfilter(
+                        &pipeline_for_pad,
+                        codec_name.as_deref(),
+                        &queue_sink_pad_for_pad,
+                    ) {
+                        Ok(Some(capsf_sink)) => capsf_sink,
+                        Ok(None) => queue_sink_pad_for_pad.clone(),
+                        Err(_) => queue_sink_pad_for_pad.clone(),
+                    }
+                } else {
+                    queue_sink_pad_for_pad.clone()
+                };
+
+                if src_pad.link(&target_pad).is_ok() {
+                    linked_video_pad_closure.store(true, Ordering::SeqCst);
+                }
+            });
+        }
+
+        let appsink = sink_elem
+            .dynamic_cast::<gst_app::AppSink>()
+            .map_err(|_| UriDemuxerError::ElementCreation("appsink cast failed".into()))?;
+
+        // Appsink callbacks (fire on GStreamer streaming thread)
+        {
+            let on_output_sample = on_output.clone();
+            let detected_codec_s = detected_codec.clone();
+            let video_info_sample = video_info.clone();
+            let stream_info_fired_sample = stream_info_fired.clone();
+            let finished_sample = finished.clone();
+            let info_pair_sample = info_pair.clone();
+            let done_pair_sample = done_pair.clone();
+            let emit_stream_info_sample = emit_stream_info.clone();
+
+            let on_output_eos = on_output.clone();
+            let finished_eos = finished.clone();
+            let info_pair_eos = info_pair.clone();
+            let done_pair_eos = done_pair.clone();
+
+            appsink.set_callbacks(
+                gst_app::AppSinkCallbacks::builder()
+                    .new_sample(move |sink| {
+                        if finished_sample.load(Ordering::SeqCst) {
+                            return Err(gst::FlowError::Eos);
+                        }
+                        let sample = sink.pull_sample().map_err(|_| gst::FlowError::Eos)?;
+                        match sample_to_packet(
+                            sample,
+                            &detected_codec_s,
+                            &video_info_sample,
+                            &stream_info_fired_sample,
+                            &info_pair_sample,
+                            emit_stream_info_sample.as_ref(),
+                        ) {
+                            Ok(pkt) => {
+                                on_output_sample(UriDemuxerOutput::Packet(pkt));
+                                Ok(gst::FlowSuccess::Ok)
+                            }
+                            Err(e) => {
+                                if !finished_sample.swap(true, Ordering::SeqCst) {
+                                    on_output_sample(UriDemuxerOutput::Error(
+                                        UriDemuxerError::from(e),
+                                    ));
+                                    signal_info_done(&info_pair_sample);
+                                    signal_done(&done_pair_sample);
+                                }
+                                Err(gst::FlowError::Error)
+                            }
+                        }
+                    })
+                    .eos(move |_| {
+                        if !finished_eos.swap(true, Ordering::SeqCst) {
+                            on_output_eos(UriDemuxerOutput::Eos);
+                            signal_info_done(&info_pair_eos);
+                            signal_done(&done_pair_eos);
+                        }
+                    })
+                    .build(),
+            );
+        }
+
+        // Bus sync handler for pipeline errors
+        if let Some(bus) = pipeline.bus() {
+            let on_output_err = on_output.clone();
+            let finished_bus = finished.clone();
+            let info_pair_bus = info_pair.clone();
+            let done_pair_bus = done_pair.clone();
+
+            bus.set_sync_handler(move |_, msg| {
+                if let gst::MessageView::Error(e) = msg.view() {
+                    if !finished_bus.swap(true, Ordering::SeqCst) {
+                        on_output_err(UriDemuxerOutput::Error(UriDemuxerError::PipelineError {
+                            src: e
+                                .src()
+                                .map(|s| s.path_string().to_string())
+                                .unwrap_or_else(|| "<unknown>".to_string()),
+                            msg: e.error().to_string(),
+                            debug: e.debug().unwrap_or_default().to_string(),
+                        }));
+                        signal_info_done(&info_pair_bus);
+                        signal_done(&done_pair_bus);
+                    }
+                    return gst::BusSyncReply::Drop;
+                }
+                gst::BusSyncReply::Pass
+            });
+        }
+
+        let ret = pipeline.set_state(gst::State::Playing);
+        if ret == Err(gst::StateChangeError) {
+            return Err(UriDemuxerError::StateChangeFailed);
+        }
+
+        Ok(Self {
+            pipeline,
+            finished,
+            detected_codec,
+            video_info,
+            info_pair,
+            stream_info_fired,
+            done_pair,
+        })
+    }
+
+    /// Block until the demuxer reaches EOS, encounters an error, or
+    /// [`finish`](Self::finish) is called.
+    pub fn wait(&self) {
+        let (lock, cvar) = &*self.done_pair;
+        let _guard = cvar
+            .wait_while(lock.lock().unwrap(), |done| !*done)
+            .unwrap();
+    }
+
+    /// Block until the demuxer finishes or the timeout expires.
+    ///
+    /// Returns `true` if the demuxer finished, `false` on timeout.
+    pub fn wait_timeout(&self, timeout: Duration) -> bool {
+        let (lock, cvar) = &*self.done_pair;
+        let (guard, _) = cvar
+            .wait_timeout_while(lock.lock().unwrap(), timeout, |done| !*done)
+            .unwrap();
+        *guard
+    }
+
+    /// Auto-detected video codec from the container, or `None` if no sample
+    /// has been processed yet.
+    pub fn detected_codec(&self) -> Option<VideoCodec> {
+        *self.detected_codec.lock().unwrap()
+    }
+
+    /// Returns [`VideoInfo`] if it has already been observed on the source pad
+    /// caps. Non-blocking.
+    pub fn video_info(&self) -> Option<VideoInfo> {
+        *self.video_info.lock().unwrap()
+    }
+
+    /// Block until [`VideoInfo`] is known, the pipeline terminates, or the
+    /// timeout expires. Returns the info or `None` on timeout / early
+    /// termination without caps.
+    pub fn wait_for_video_info(&self, timeout: Duration) -> Option<VideoInfo> {
+        if self.stream_info_fired.load(Ordering::SeqCst) {
+            return self.video_info();
+        }
+        let (lock, cvar) = &*self.info_pair;
+        let (guard, _) = cvar
+            .wait_timeout_while(lock.lock().unwrap(), timeout, |known_or_done| {
+                !*known_or_done
+            })
+            .unwrap();
+        if !*guard {
+            return None;
+        }
+        drop(guard);
+        self.video_info()
+    }
+
+    /// Stop the pipeline and release resources.
+    ///
+    /// Safe to call multiple times. After this call, no more callbacks will
+    /// fire.
+    ///
+    /// # Panics
+    ///
+    /// Must **not** be called from within the `on_output` callback (deadlock).
+    pub fn finish(&mut self) {
+        let was_finished = self.finished.swap(true, Ordering::SeqCst);
+        let _ = self.pipeline.set_state(gst::State::Null);
+        if !was_finished {
+            signal_info_done(&self.info_pair);
+            signal_done(&self.done_pair);
+        }
+    }
+
+    /// Whether the demuxer has been finalized (EOS, error, or explicit
+    /// `finish()`).
+    pub fn is_finished(&self) -> bool {
+        self.finished.load(Ordering::SeqCst)
+    }
+}
+
+impl Drop for UriDemuxer {
+    fn drop(&mut self) {
+        self.finish();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mp4_muxer::Mp4Muxer;
+    use std::path::Path;
+
+    const H264_SPS_PPS_IDR: [u8; 32] = [
+        0x00, 0x00, 0x00, 0x01, 0x67, 0x42, 0x00, 0x0A, 0xE9, 0x40, 0x40, 0x04, 0x00, 0x00, 0x00,
+        0x02, 0x00, 0x00, 0x00, 0x01, 0x68, 0xCE, 0x38, 0x80, 0x00, 0x00, 0x00, 0x01, 0x65, 0x88,
+        0x80, 0x40,
+    ];
+
+    fn make_h264_mp4(path: &str, num_frames: usize) {
+        let mut muxer = Mp4Muxer::new(VideoCodec::H264, path, 30, 1).unwrap();
+        let duration_ns = 33_333_333u64;
+        for i in 0..num_frames {
+            muxer
+                .push(
+                    &H264_SPS_PPS_IDR,
+                    (i as u64) * duration_ns,
+                    None,
+                    Some(duration_ns),
+                )
+                .unwrap();
+        }
+        muxer.finish().unwrap();
+    }
+
+    fn file_uri(path: &str) -> String {
+        format!("file://{}", Path::new(path).display())
+    }
+
+    #[test]
+    fn test_rejects_empty_uri() {
+        let result = UriDemuxer::new(UriDemuxerConfig::new(""), |_| {});
+        assert!(matches!(result, Err(UriDemuxerError::MissingUri)));
+    }
+
+    #[test]
+    fn test_rejects_malformed_uri() {
+        // No scheme separator — not a valid URI.
+        let result = UriDemuxer::new(UriDemuxerConfig::new("not a uri at all"), |_| {});
+        assert!(matches!(result, Err(UriDemuxerError::InvalidUri(_))));
+    }
+
+    #[test]
+    fn test_file_uri_happy_path() {
+        let _ = gst::init();
+        let path = "/tmp/test_uri_demuxer_happy.mp4";
+        let _ = std::fs::remove_file(path);
+        make_h264_mp4(path, 5);
+
+        let packets: Arc<Mutex<Vec<DemuxedPacket>>> = Arc::new(Mutex::new(Vec::new()));
+        let got_eos = Arc::new(AtomicBool::new(false));
+        let packets_cb = packets.clone();
+        let got_eos_cb = got_eos.clone();
+
+        let demuxer = UriDemuxer::new(
+            UriDemuxerConfig::new(file_uri(path)).with_parsed(true),
+            move |out| match out {
+                UriDemuxerOutput::Packet(p) => packets_cb.lock().unwrap().push(p),
+                UriDemuxerOutput::Eos => got_eos_cb.store(true, Ordering::SeqCst),
+                UriDemuxerOutput::Error(e) => panic!("unexpected error: {e}"),
+                UriDemuxerOutput::StreamInfo(_) => {}
+            },
+        )
+        .unwrap();
+
+        demuxer.wait();
+        assert!(!packets.lock().unwrap().is_empty());
+        assert!(got_eos.load(Ordering::SeqCst));
+        assert_eq!(demuxer.detected_codec(), Some(VideoCodec::H264));
+        let info = demuxer.video_info().expect("video info expected");
+        assert_eq!(info.codec, VideoCodec::H264);
+        assert!(info.width > 0);
+        assert!(info.height > 0);
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn test_wait_for_video_info_returns_info() {
+        let _ = gst::init();
+        let path = "/tmp/test_uri_demuxer_wait_info.mp4";
+        let _ = std::fs::remove_file(path);
+        make_h264_mp4(path, 3);
+
+        let demuxer = UriDemuxer::new(UriDemuxerConfig::new(file_uri(path)), |_| {}).unwrap();
+        let info = demuxer.wait_for_video_info(Duration::from_secs(5));
+        let info = info.expect("video info expected");
+        assert_eq!(info.codec, VideoCodec::H264);
+        assert!(info.width > 0);
+        assert!(info.height > 0);
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn test_unknown_bin_property_rejected() {
+        let _ = gst::init();
+        let path = "/tmp/test_uri_demuxer_bad_bin_prop.mp4";
+        let _ = std::fs::remove_file(path);
+        make_h264_mp4(path, 1);
+
+        let result = UriDemuxer::new(
+            UriDemuxerConfig::new(file_uri(path))
+                .with_bin_property("definitely-not-a-real-property", 42i32),
+            |_| {},
+        );
+        assert!(
+            matches!(
+                result,
+                Err(UriDemuxerError::PropertyError { ref name, .. }) if name == "definitely-not-a-real-property"
+            ),
+            "expected PropertyError, got {:?}",
+            result.as_ref().err()
+        );
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn test_unknown_source_property_surfaces_in_callback() {
+        let _ = gst::init();
+        let path = "/tmp/test_uri_demuxer_bad_src_prop.mp4";
+        let _ = std::fs::remove_file(path);
+        make_h264_mp4(path, 1);
+
+        let errors: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let errors_cb = errors.clone();
+        let demuxer = UriDemuxer::new(
+            UriDemuxerConfig::new(file_uri(path))
+                // filesrc has no `latency` property — should surface as
+                // PropertyError in the callback (not break the pipeline).
+                .with_source_property("definitely-not-a-real-property", 200u32),
+            move |out| {
+                if let UriDemuxerOutput::Error(UriDemuxerError::PropertyError { name, .. }) = out {
+                    errors_cb.lock().unwrap().push(name);
+                }
+            },
+        )
+        .unwrap();
+
+        demuxer.wait_timeout(Duration::from_secs(5));
+        let errs = errors.lock().unwrap();
+        assert!(
+            errs.iter().any(|n| n == "definitely-not-a-real-property"),
+            "expected PropertyError for unknown source property, got {errs:?}"
+        );
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn test_finish_idempotent() {
+        let _ = gst::init();
+        let path = "/tmp/test_uri_demuxer_finish.mp4";
+        let _ = std::fs::remove_file(path);
+        make_h264_mp4(path, 1);
+
+        let mut demuxer = UriDemuxer::new(UriDemuxerConfig::new(file_uri(path)), |_| {}).unwrap();
+        demuxer.finish();
+        demuxer.finish();
+        assert!(demuxer.is_finished());
+
+        let _ = std::fs::remove_file(path);
+    }
+}

--- a/savant_gstreamer/savant_gstreamer/src/uri_demuxer.rs
+++ b/savant_gstreamer/savant_gstreamer/src/uri_demuxer.rs
@@ -194,7 +194,7 @@ impl ByteStreamCapsfilter {
 ///
 /// This only rejects obviously malformed values up front; GStreamer does the
 /// real validation at state-change time.
-fn is_plausible_uri(uri: &str) -> bool {
+pub fn is_plausible_uri(uri: &str) -> bool {
     let Some(scheme_end) = uri.find("://") else {
         return false;
     };

--- a/savant_gstreamer/savant_gstreamer/tests/demuxer_parity.rs
+++ b/savant_gstreamer/savant_gstreamer/tests/demuxer_parity.rs
@@ -7,23 +7,29 @@
 //! - `VideoInfo`,
 //! - `detected_codec`.
 //!
-//! H.264 payload comparison is done on a **normalized** form: leading
-//! configuration NAL units (AUD / SPS / PPS / SEI) are stripped via
-//! `cros-codecs` so the slice NAL remains. The raw SPS/PPS prefix count
-//! differs legitimately between the two paths because `UriDemuxer` uses
-//! `parsebin` (whose internal parser chain handles SPS/PPS insertion
-//! slightly differently than `Mp4Demuxer`'s direct `qtdemux -> h264parse`
-//! chain). Downstream decoders handle both formats identically, and the
-//! slice bytes (the actual encoded video data) are byte-identical.
+//! H.264/HEVC payload comparison is done on a **normalized** form: leading
+//! configuration NAL units (AUD / VPS / SPS / PPS / SEI / filler / EoS / EoB)
+//! are stripped via `cros-codecs` so the slice NAL remains. The raw SPS/PPS
+//! prefix count differs legitimately between the two paths because
+//! `UriDemuxer` uses `parsebin` (whose internal parser chain handles
+//! SPS/PPS insertion slightly differently than `Mp4Demuxer`'s direct
+//! `qtdemux -> h26{4,5}parse` chain). Downstream decoders handle both
+//! formats identically, and the slice bytes (the actual encoded video
+//! data) are byte-identical.
+//!
+//! For codecs that are **not** carried in Annex-B form by `parsed=true`
+//! (`Av1`, `Vp8`, `Vp9`, `Jpeg`), payloads are compared byte-for-byte.
 
 use std::io::Cursor;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use cros_codecs::codec::h264::parser::{Nalu as H264Nalu, NaluType as H264NaluType};
+use cros_codecs::codec::h265::parser::{Nalu as H265Nalu, NaluType as H265NaluType};
 use gstreamer as gst;
+use serde::Deserialize;
 
 use savant_core::primitives::video_codec::VideoCodec;
 use savant_gstreamer::demux::{DemuxedPacket, VideoInfo};
@@ -85,25 +91,53 @@ fn collect_via_uri_demuxer(
     (pkts, info, codec)
 }
 
-/// Extract the slice NAL units from an Annex-B H.264 access unit using
-/// `cros-codecs`, discarding configuration NALs (AUD / SPS / PPS / SEI /
-/// FillerData / SeqEnd / StreamEnd).
-fn h264_slice_nals(au: &[u8]) -> Vec<Vec<u8>> {
+/// Extract slice (VCL) NAL units from an Annex-B access unit, discarding
+/// configuration NALs (parameter sets, SEI, AUD, filler, end-of-sequence /
+/// end-of-bitstream markers, ...). Returns one `Vec<u8>` per VCL NALU,
+/// including the NALU header byte but **not** the start code.
+///
+/// This normalisation is what lets us compare payloads from `Mp4Demuxer`
+/// (which goes `qtdemux → h264parse/h265parse(-1)`) against `UriDemuxer`
+/// (which goes `parsebin(internal h264parse/h265parse(-1)) → byte-stream
+/// capsfilter`): both pipelines emit the same slice bytes, but they may
+/// differ in how often / where they re-emit SPS/PPS/VPS/AUD/SEI.
+fn slice_nals(codec: VideoCodec, au: &[u8]) -> Vec<Vec<u8>> {
     let mut cur = Cursor::new(au);
     let mut slices = Vec::new();
-    while let Ok(nalu) = H264Nalu::next(&mut cur) {
-        match nalu.header.type_ {
-            H264NaluType::AuDelimiter
-            | H264NaluType::Sps
-            | H264NaluType::Pps
-            | H264NaluType::Sei
-            | H264NaluType::FillerData
-            | H264NaluType::SeqEnd
-            | H264NaluType::StreamEnd
-            | H264NaluType::SpsExt
-            | H264NaluType::SubsetSps => {}
-            _ => slices.push(nalu.as_ref().to_vec()),
+    match codec {
+        VideoCodec::H264 => {
+            while let Ok(nalu) = H264Nalu::next(&mut cur) {
+                match nalu.header.type_ {
+                    H264NaluType::AuDelimiter
+                    | H264NaluType::Sps
+                    | H264NaluType::Pps
+                    | H264NaluType::Sei
+                    | H264NaluType::FillerData
+                    | H264NaluType::SeqEnd
+                    | H264NaluType::StreamEnd
+                    | H264NaluType::SpsExt
+                    | H264NaluType::SubsetSps => {}
+                    _ => slices.push(nalu.as_ref().to_vec()),
+                }
+            }
         }
+        VideoCodec::Hevc => {
+            while let Ok(nalu) = H265Nalu::next(&mut cur) {
+                match nalu.header.type_ {
+                    H265NaluType::VpsNut
+                    | H265NaluType::SpsNut
+                    | H265NaluType::PpsNut
+                    | H265NaluType::AudNut
+                    | H265NaluType::EosNut
+                    | H265NaluType::EobNut
+                    | H265NaluType::FdNut
+                    | H265NaluType::PrefixSeiNut
+                    | H265NaluType::SuffixSeiNut => {}
+                    _ => slices.push(nalu.as_ref().to_vec()),
+                }
+            }
+        }
+        other => panic!("slice_nals: unsupported codec {other:?}"),
     }
     slices
 }
@@ -150,8 +184,8 @@ fn test_mp4_vs_uri_demuxer_h264_parity() {
         }
 
         // Byte-level comparison of slice NAL units (configuration-agnostic).
-        let r_slices = h264_slice_nals(&r.data);
-        let u_slices = h264_slice_nals(&u.data);
+        let r_slices = slice_nals(VideoCodec::H264, &r.data);
+        let u_slices = slice_nals(VideoCodec::H264, &u.data);
         assert_eq!(
             r_slices, u_slices,
             "packet[{idx}] slice NAL units differ\nmp4:  {:?}\nuri:  {:?}",
@@ -164,4 +198,342 @@ fn test_mp4_vs_uri_demuxer_h264_parity() {
     }
 
     let _ = std::fs::remove_file(path);
+}
+
+// ── Manifest-driven sweep over `decoders/assets/` fixtures ──────────────────
+
+/// Subset of `savant_deepstream/decoders/assets/manifest.json` used by these
+/// parity tests. Fields we don't need are omitted; `serde(default)` keeps
+/// the schema forward-compatible.
+#[derive(Debug, Deserialize)]
+struct Manifest {
+    assets: Vec<AssetEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AssetEntry {
+    file: String,
+    #[serde(default)]
+    container: Option<String>,
+    codec: String,
+    #[serde(default)]
+    stream_format: Option<String>,
+    width: u32,
+    height: u32,
+    num_frames: u32,
+}
+
+/// Path to the shared fixtures directory:
+/// `savant_gstreamer/savant_gstreamer/../../savant_deepstream/decoders/assets`.
+fn assets_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../savant_deepstream/decoders/assets")
+}
+
+/// Load the asset manifest, or return `None` if it is absent (stripped
+/// checkout). All other I/O / parse errors are panics so a malformed
+/// manifest doesn't silently disable the sweep.
+fn load_manifest() -> Option<Manifest> {
+    let path = assets_dir().join("manifest.json");
+    if !path.exists() {
+        eprintln!(
+            "demuxer_parity: skipping manifest sweep — {} not found",
+            path.display()
+        );
+        return None;
+    }
+    let data = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
+    let m: Manifest = serde_json::from_str(&data)
+        .unwrap_or_else(|e| panic!("cannot parse {}: {e}", path.display()));
+    Some(m)
+}
+
+fn manifest_codec_to_video_codec(name: &str) -> VideoCodec {
+    match name {
+        "h264" => VideoCodec::H264,
+        "hevc" => VideoCodec::Hevc,
+        "av1" => VideoCodec::Av1,
+        "vp8" => VideoCodec::Vp8,
+        "vp9" => VideoCodec::Vp9,
+        "jpeg" => VideoCodec::Jpeg,
+        other => panic!("unknown manifest codec '{other}'"),
+    }
+}
+
+/// MP4 sweep: for every `container=mp4` fixture, assert `Mp4Demuxer` and
+/// `UriDemuxer` produce the same VideoInfo, packet count, per-packet
+/// timing/flags, and equivalent payloads.
+#[test]
+fn test_manifest_mp4_parity() {
+    let _ = gst::init();
+    let Some(manifest) = load_manifest() else {
+        return;
+    };
+
+    let assets_dir = assets_dir();
+    let mut tested = 0usize;
+    let mut failures: Vec<String> = Vec::new();
+
+    for entry in manifest
+        .assets
+        .iter()
+        .filter(|e| e.container.as_deref() == Some("mp4"))
+    {
+        let asset_path = assets_dir.join(&entry.file);
+        if !asset_path.exists() {
+            eprintln!(
+                "demuxer_parity: SKIP missing fixture {}",
+                asset_path.display()
+            );
+            continue;
+        }
+        let asset_path_str = asset_path.to_str().expect("non-UTF8 path");
+
+        if let Err(e) = check_mp4_parity(entry, asset_path_str) {
+            failures.push(format!("{}: {e}", entry.file));
+        }
+        tested += 1;
+    }
+
+    assert!(
+        tested > 0,
+        "demuxer_parity: no MP4 fixtures found under {}",
+        assets_dir.display()
+    );
+    assert!(
+        failures.is_empty(),
+        "MP4 parity failed for {}/{} fixtures:\n  - {}",
+        failures.len(),
+        tested,
+        failures.join("\n  - ")
+    );
+}
+
+/// Run both demuxers on a single MP4 and assert parity. Returns `Err` with
+/// a human-readable reason on mismatch so the caller can aggregate
+/// failures across the whole manifest.
+fn check_mp4_parity(entry: &AssetEntry, asset_path: &str) -> Result<(), String> {
+    let expected_codec = manifest_codec_to_video_codec(&entry.codec);
+
+    let (ref_packets, ref_info) =
+        Mp4Demuxer::demux_all_parsed(asset_path).map_err(|e| format!("Mp4Demuxer failed: {e}"))?;
+    let (uri_packets, uri_info, uri_codec) = collect_via_uri_demuxer(&file_uri(asset_path));
+    let ref_codec = ref_info.map(|i| i.codec);
+
+    if ref_codec != uri_codec {
+        return Err(format!(
+            "detected_codec mismatch: mp4={ref_codec:?} uri={uri_codec:?}"
+        ));
+    }
+    if ref_info != uri_info {
+        return Err(format!(
+            "VideoInfo mismatch: mp4={ref_info:?} uri={uri_info:?}"
+        ));
+    }
+
+    let info = ref_info.ok_or_else(|| "no VideoInfo emitted by Mp4Demuxer".to_string())?;
+    if info.codec != expected_codec {
+        return Err(format!(
+            "codec mismatch vs manifest: got {:?}, expected {:?}",
+            info.codec, expected_codec
+        ));
+    }
+    if info.width != entry.width || info.height != entry.height {
+        return Err(format!(
+            "dimensions mismatch vs manifest: got {}x{}, expected {}x{}",
+            info.width, info.height, entry.width, entry.height
+        ));
+    }
+
+    if ref_packets.len() != uri_packets.len() {
+        return Err(format!(
+            "packet count mismatch: mp4={} uri={}",
+            ref_packets.len(),
+            uri_packets.len()
+        ));
+    }
+    if (ref_packets.len() as u32) < entry.num_frames {
+        return Err(format!(
+            "packet count {} below manifest num_frames {}",
+            ref_packets.len(),
+            entry.num_frames
+        ));
+    }
+
+    // Frame timestamps derived from non-integer ns framerates (e.g.
+    // 1/30 s = 33_333_333.333… ns) may legitimately round to neighbouring
+    // integers between the two parser paths. We tolerate up to 1 ns of
+    // drift per accumulated frame on PTS/DTS, and ±1 ns on each per-frame
+    // duration; anything larger is a real divergence.
+    const NS_PER_FRAME_TOLERANCE: u64 = 1;
+
+    let mut saw_keyframe = false;
+    for (idx, (r, u)) in ref_packets.iter().zip(uri_packets.iter()).enumerate() {
+        let ts_tol = (idx as u64 + 1) * NS_PER_FRAME_TOLERANCE;
+        let pts_diff = r.pts_ns.abs_diff(u.pts_ns);
+        if pts_diff > ts_tol {
+            return Err(format!(
+                "packet[{idx}] pts_ns differ by {pts_diff} ns (tolerance {ts_tol}): mp4={} uri={}",
+                r.pts_ns, u.pts_ns
+            ));
+        }
+        if r.is_keyframe != u.is_keyframe {
+            return Err(format!(
+                "packet[{idx}] is_keyframe differ: mp4={} uri={}",
+                r.is_keyframe, u.is_keyframe
+            ));
+        }
+        if r.is_keyframe {
+            saw_keyframe = true;
+        }
+        if let (Some(rd), Some(ud)) = (r.dts_ns, u.dts_ns) {
+            let diff = rd.abs_diff(ud);
+            if diff > ts_tol {
+                return Err(format!(
+                    "packet[{idx}] dts_ns differ by {diff} ns (tolerance {ts_tol}): mp4={rd} uri={ud}"
+                ));
+            }
+        }
+        if let (Some(rd), Some(ud)) = (r.duration_ns, u.duration_ns) {
+            let diff = rd.abs_diff(ud);
+            if diff > NS_PER_FRAME_TOLERANCE {
+                return Err(format!(
+                    "packet[{idx}] duration_ns differ by {diff} ns: mp4={rd} uri={ud}"
+                ));
+            }
+        }
+
+        match info.codec {
+            VideoCodec::H264 | VideoCodec::Hevc => {
+                let r_slices = slice_nals(info.codec, &r.data);
+                let u_slices = slice_nals(info.codec, &u.data);
+                if r_slices != u_slices {
+                    return Err(format!(
+                        "packet[{idx}] slice NAL units differ\n  mp4: {:?}\n  uri: {:?}",
+                        r.data, u.data
+                    ));
+                }
+                if r_slices.is_empty() {
+                    return Err(format!("packet[{idx}] has no slice NALs (mp4)"));
+                }
+            }
+            VideoCodec::Av1 | VideoCodec::Vp8 | VideoCodec::Vp9 | VideoCodec::Jpeg => {
+                if r.data != u.data {
+                    return Err(format!(
+                        "packet[{idx}] data bytes differ ({} vs {} bytes)",
+                        r.data.len(),
+                        u.data.len()
+                    ));
+                }
+            }
+            other => return Err(format!("unsupported codec for parity check: {other:?}")),
+        }
+    }
+
+    if !saw_keyframe {
+        return Err("no keyframe seen in either demuxer output".into());
+    }
+
+    Ok(())
+}
+
+/// Raw Annex-B sweep: `Mp4Demuxer` cannot ingest these (no qtdemux step),
+/// so we only verify that `UriDemuxer` produces the expected codec /
+/// dimensions and emits at least one VCL slice across all packets.
+#[test]
+fn test_manifest_raw_annexb_uri_demuxer() {
+    let _ = gst::init();
+    let Some(manifest) = load_manifest() else {
+        return;
+    };
+
+    let assets_dir = assets_dir();
+    let mut tested = 0usize;
+    let mut failures: Vec<String> = Vec::new();
+
+    for entry in manifest
+        .assets
+        .iter()
+        .filter(|e| e.container.as_deref() == Some("raw"))
+    {
+        let asset_path = assets_dir.join(&entry.file);
+        if !asset_path.exists() {
+            eprintln!(
+                "demuxer_parity: SKIP missing fixture {}",
+                asset_path.display()
+            );
+            continue;
+        }
+        let asset_path_str = asset_path.to_str().expect("non-UTF8 path");
+        if let Err(e) = check_raw_annexb(entry, asset_path_str) {
+            failures.push(format!("{}: {e}", entry.file));
+        }
+        tested += 1;
+    }
+
+    assert!(
+        tested > 0,
+        "demuxer_parity: no raw Annex-B fixtures found under {}",
+        assets_dir.display()
+    );
+    assert!(
+        failures.is_empty(),
+        "raw Annex-B UriDemuxer failed for {}/{} fixtures:\n  - {}",
+        failures.len(),
+        tested,
+        failures.join("\n  - ")
+    );
+}
+
+fn check_raw_annexb(entry: &AssetEntry, asset_path: &str) -> Result<(), String> {
+    let expected_codec = manifest_codec_to_video_codec(&entry.codec);
+    if !matches!(expected_codec, VideoCodec::H264 | VideoCodec::Hevc) {
+        return Err(format!(
+            "raw Annex-B fixtures must be H.264 or HEVC, got {:?}",
+            expected_codec
+        ));
+    }
+    if entry.stream_format.as_deref() != Some("byte-stream") {
+        return Err(format!(
+            "expected stream_format=byte-stream, got {:?}",
+            entry.stream_format
+        ));
+    }
+
+    let (uri_packets, uri_info, uri_codec) = collect_via_uri_demuxer(&file_uri(asset_path));
+
+    if uri_codec != Some(expected_codec) {
+        return Err(format!(
+            "detected_codec mismatch: got {uri_codec:?}, expected {expected_codec:?}"
+        ));
+    }
+    let info = uri_info.ok_or_else(|| "no VideoInfo emitted by UriDemuxer".to_string())?;
+    if info.codec != expected_codec {
+        return Err(format!(
+            "VideoInfo.codec mismatch: got {:?}, expected {:?}",
+            info.codec, expected_codec
+        ));
+    }
+    if info.width != entry.width || info.height != entry.height {
+        return Err(format!(
+            "dimensions mismatch vs manifest: got {}x{}, expected {}x{}",
+            info.width, info.height, entry.width, entry.height
+        ));
+    }
+    if uri_packets.is_empty() {
+        return Err("UriDemuxer produced 0 packets".into());
+    }
+
+    // Concatenate all packets and assert at least one VCL slice — the
+    // byte-stream capsfilter / parsebin chain must keep slice NALs intact.
+    let mut bytestream = Vec::new();
+    for pkt in &uri_packets {
+        bytestream.extend_from_slice(&pkt.data);
+    }
+    let slices = slice_nals(expected_codec, &bytestream);
+    if slices.is_empty() {
+        return Err("no VCL slice NAL units recovered from UriDemuxer output".into());
+    }
+
+    Ok(())
 }

--- a/savant_gstreamer/savant_gstreamer/tests/demuxer_parity.rs
+++ b/savant_gstreamer/savant_gstreamer/tests/demuxer_parity.rs
@@ -1,0 +1,167 @@
+//! Parity integration test: `Mp4Demuxer` (ground truth) vs `UriDemuxer`.
+//!
+//! Both demuxers are run against the same generated MP4 and their outputs
+//! compared. Strict equality is asserted for:
+//! - packet count,
+//! - `pts_ns`, `dts_ns`, `duration_ns`, `is_keyframe` per packet,
+//! - `VideoInfo`,
+//! - `detected_codec`.
+//!
+//! H.264 payload comparison is done on a **normalized** form: leading
+//! configuration NAL units (AUD / SPS / PPS / SEI) are stripped via
+//! `cros-codecs` so the slice NAL remains. The raw SPS/PPS prefix count
+//! differs legitimately between the two paths because `UriDemuxer` uses
+//! `parsebin` (whose internal parser chain handles SPS/PPS insertion
+//! slightly differently than `Mp4Demuxer`'s direct `qtdemux -> h264parse`
+//! chain). Downstream decoders handle both formats identically, and the
+//! slice bytes (the actual encoded video data) are byte-identical.
+
+use std::io::Cursor;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use cros_codecs::codec::h264::parser::{Nalu as H264Nalu, NaluType as H264NaluType};
+use gstreamer as gst;
+
+use savant_core::primitives::video_codec::VideoCodec;
+use savant_gstreamer::demux::{DemuxedPacket, VideoInfo};
+use savant_gstreamer::mp4_demuxer::Mp4Demuxer;
+use savant_gstreamer::mp4_muxer::Mp4Muxer;
+use savant_gstreamer::uri_demuxer::{UriDemuxer, UriDemuxerConfig, UriDemuxerOutput};
+
+const H264_SPS_PPS_IDR: [u8; 32] = [
+    0x00, 0x00, 0x00, 0x01, 0x67, 0x42, 0x00, 0x0A, 0xE9, 0x40, 0x40, 0x04, 0x00, 0x00, 0x00, 0x02,
+    0x00, 0x00, 0x00, 0x01, 0x68, 0xCE, 0x38, 0x80, 0x00, 0x00, 0x00, 0x01, 0x65, 0x88, 0x80, 0x40,
+];
+
+fn make_h264_mp4(path: &str, num_frames: usize) {
+    let mut muxer = Mp4Muxer::new(VideoCodec::H264, path, 30, 1).unwrap();
+    let duration_ns = 33_333_333u64;
+    for i in 0..num_frames {
+        muxer
+            .push(
+                &H264_SPS_PPS_IDR,
+                (i as u64) * duration_ns,
+                None,
+                Some(duration_ns),
+            )
+            .unwrap();
+    }
+    muxer.finish().unwrap();
+}
+
+fn file_uri(path: &str) -> String {
+    format!("file://{}", Path::new(path).display())
+}
+
+fn collect_via_uri_demuxer(
+    uri: &str,
+) -> (Vec<DemuxedPacket>, Option<VideoInfo>, Option<VideoCodec>) {
+    let packets: Arc<Mutex<Vec<DemuxedPacket>>> = Arc::new(Mutex::new(Vec::new()));
+    let errored = Arc::new(AtomicBool::new(false));
+    let packets_cb = packets.clone();
+    let errored_cb = errored.clone();
+    let demuxer = UriDemuxer::new(
+        UriDemuxerConfig::new(uri).with_parsed(true),
+        move |out| match out {
+            UriDemuxerOutput::Packet(p) => packets_cb.lock().unwrap().push(p),
+            UriDemuxerOutput::Error(e) => {
+                errored_cb.store(true, Ordering::SeqCst);
+                panic!("UriDemuxer error: {e}");
+            }
+            _ => {}
+        },
+    )
+    .unwrap();
+    assert!(
+        demuxer.wait_timeout(Duration::from_secs(10)),
+        "UriDemuxer timed out"
+    );
+    let info = demuxer.video_info();
+    let codec = demuxer.detected_codec();
+    let pkts = std::mem::take(&mut *packets.lock().unwrap());
+    (pkts, info, codec)
+}
+
+/// Extract the slice NAL units from an Annex-B H.264 access unit using
+/// `cros-codecs`, discarding configuration NALs (AUD / SPS / PPS / SEI /
+/// FillerData / SeqEnd / StreamEnd).
+fn h264_slice_nals(au: &[u8]) -> Vec<Vec<u8>> {
+    let mut cur = Cursor::new(au);
+    let mut slices = Vec::new();
+    while let Ok(nalu) = H264Nalu::next(&mut cur) {
+        match nalu.header.type_ {
+            H264NaluType::AuDelimiter
+            | H264NaluType::Sps
+            | H264NaluType::Pps
+            | H264NaluType::Sei
+            | H264NaluType::FillerData
+            | H264NaluType::SeqEnd
+            | H264NaluType::StreamEnd
+            | H264NaluType::SpsExt
+            | H264NaluType::SubsetSps => {}
+            _ => slices.push(nalu.as_ref().to_vec()),
+        }
+    }
+    slices
+}
+
+#[test]
+fn test_mp4_vs_uri_demuxer_h264_parity() {
+    let _ = gst::init();
+    let path = "/tmp/test_demuxer_parity_h264.mp4";
+    let _ = std::fs::remove_file(path);
+    make_h264_mp4(path, 10);
+
+    // Ground truth via Mp4Demuxer.
+    let (ref_packets, ref_info) = Mp4Demuxer::demux_all_parsed(path).expect("Mp4Demuxer failed");
+    let ref_codec = ref_info.map(|i| i.codec);
+
+    // Candidate via UriDemuxer.
+    let (uri_packets, uri_info, uri_codec) = collect_via_uri_demuxer(&file_uri(path));
+
+    // Strict parity on codec + VideoInfo.
+    assert_eq!(ref_codec, uri_codec, "detected_codec mismatch");
+    assert_eq!(ref_info, uri_info, "VideoInfo mismatch");
+
+    // Strict parity on packet count.
+    assert_eq!(
+        ref_packets.len(),
+        uri_packets.len(),
+        "packet count mismatch: mp4={} uri={}",
+        ref_packets.len(),
+        uri_packets.len()
+    );
+
+    // Strict parity on per-packet timing/flags + semantic parity on payload.
+    for (idx, (r, u)) in ref_packets.iter().zip(uri_packets.iter()).enumerate() {
+        assert_eq!(r.pts_ns, u.pts_ns, "packet[{idx}] pts_ns differ");
+        assert_eq!(
+            r.is_keyframe, u.is_keyframe,
+            "packet[{idx}] is_keyframe differ"
+        );
+        if let (Some(rd), Some(ud)) = (r.dts_ns, u.dts_ns) {
+            assert_eq!(rd, ud, "packet[{idx}] dts_ns differ");
+        }
+        if let (Some(rd), Some(ud)) = (r.duration_ns, u.duration_ns) {
+            assert_eq!(rd, ud, "packet[{idx}] duration_ns differ");
+        }
+
+        // Byte-level comparison of slice NAL units (configuration-agnostic).
+        let r_slices = h264_slice_nals(&r.data);
+        let u_slices = h264_slice_nals(&u.data);
+        assert_eq!(
+            r_slices, u_slices,
+            "packet[{idx}] slice NAL units differ\nmp4:  {:?}\nuri:  {:?}",
+            r.data, u.data
+        );
+        assert!(
+            !r_slices.is_empty(),
+            "packet[{idx}] has no slice NALs (mp4)"
+        );
+    }
+
+    let _ = std::fs::remove_file(path);
+}

--- a/savant_perception/examples/cars_demo/cars_tracking/pipeline.rs
+++ b/savant_perception/examples/cars_demo/cars_tracking/pipeline.rs
@@ -1,8 +1,13 @@
 //! End-to-end streaming orchestrator for the `cars_tracking` sample.
 //!
 //! ```text
-//! Mp4Demuxer -> FlexibleDecoderPool -> NvInfer -> NvTracker -> Picasso -> Mp4Muxer
+//! Mp4Demuxer | UriDemuxer -> FlexibleDecoderPool -> NvInfer -> NvTracker -> Picasso -> Mp4Muxer
 //! ```
+//!
+//! The demuxer actor is selected from the resolved CLI input: a
+//! filesystem path uses [`Mp4DemuxerSource`] (bit-identical legacy
+//! behaviour); a URI (`file://`, `http://`, `rtsp://`, `rtmp://`,
+//! `hls://`, …) uses [`UriDemuxerSource`].
 //!
 //! This module is **orchestration only** — per-actor behaviour lives
 //! inside the framework Layer-B templates
@@ -56,7 +61,7 @@ use crate::cars_tracking::stats::{
     make_stage, stage_frames, stage_objects, tick_stage, PipelineStats,
 };
 use crate::cars_tracking::warmup::prepare_nvinfer_operator;
-use crate::cli::ResolvedCli;
+use crate::cli::{InputSource, ResolvedCli};
 use savant_perception::envelopes::{EncodedMsg, PipelineMsg};
 use savant_perception::router::Router;
 use savant_perception::shutdown::{ShutdownAction, ShutdownCause, ShutdownCtx};
@@ -65,7 +70,7 @@ use savant_perception::templates::decoder::make_decode_frame;
 use savant_perception::templates::{
     BitstreamFunction, BitstreamFunctionInbox, Decoder, DecoderResults, Function, FunctionInbox,
     Mp4DemuxerResults, Mp4DemuxerSource, Mp4Muxer, NvInfer, NvInferResults, NvTracker,
-    NvTrackerResults, Picasso, PicassoInbox,
+    NvTrackerResults, Picasso, PicassoInbox, UriDemuxerResults, UriDemuxerSource,
 };
 use savant_perception::{Flow, HookCtx, System};
 
@@ -94,8 +99,18 @@ const ROLE_TAIL: &str = "tail";
 /// Run the cars-tracking pipeline end-to-end.  Blocks until the input
 /// MP4 is fully processed and the output MP4 is finalized.
 pub fn run(cli: ResolvedCli) -> Result<()> {
-    if !cli.input.is_file() {
-        bail!("input file does not exist: {}", cli.input.display());
+    // Path inputs still need the existence / file-type guard here
+    // (the CLI validates existence, but re-checking at pipeline
+    // entry catches unit-test ResolvedCli literals and late
+    // filesystem changes).  URI inputs are opaque — any addressing
+    // error surfaces when the URI demuxer actually starts.
+    match &cli.input {
+        InputSource::Path(p) => {
+            if !p.is_file() {
+                bail!("input file does not exist: {}", p.display());
+            }
+        }
+        InputSource::Uri(_) => {}
     }
     // The `--output null` sentinel (`output_is_null = true`) keeps
     // Picasso running but redirects the encoded bitstream into a
@@ -121,7 +136,7 @@ pub fn run(cli: ResolvedCli) -> Result<()> {
 
     log::info!(
         "cars-demo starting: input={} output={} gpu={} conf={} iou={} channel_cap={} fps={}/{} picasso_enabled={} draw_enabled={} debug={}",
-        cli.input.display(),
+        cli.input,
         cli.output
             .as_ref()
             .map(|p| p.display().to_string())
@@ -162,7 +177,14 @@ pub fn run(cli: ResolvedCli) -> Result<()> {
     let tracker_stats = Arc::new(TrackerStats::new());
 
     // ── Stage identities ────────────────────────────────────────────────
-    let demux_name = StageName::unnamed(StageKind::Mp4Demux);
+    //
+    // The demuxer's stage-kind tracks the resolved input variant so
+    // logs and supervisor policy can disambiguate `mp4_demux` vs
+    // `uri_demux` pipelines.
+    let demux_name = match &cli.input {
+        InputSource::Path(_) => StageName::unnamed(StageKind::Mp4Demux),
+        InputSource::Uri(_) => StageName::unnamed(StageKind::UriDemux),
+    };
     let decoder_name = StageName::unnamed(StageKind::Decoder);
     let infer_name = StageName::unnamed(StageKind::Infer);
     let tracker_name = StageName::unnamed(StageKind::Tracker);
@@ -209,41 +231,83 @@ pub fn run(cli: ResolvedCli) -> Result<()> {
 
     // ── Demuxer source ──────────────────────────────────────────────────
     //
-    // The `Mp4DemuxerSource` template never calls `router.send` itself.
-    // Every downstream dispatch below happens inside user code — the
-    // variant hooks receive `&Router<EncodedMsg>` and the sample
-    // chooses the default peer via plain `router.send(...)`.  Source
-    // operators that need to route differently per `source_id` (e.g.
-    // fan out to distinct decoder pools) would call
+    // Neither the `Mp4DemuxerSource` nor the `UriDemuxerSource`
+    // template calls `router.send` itself.  Every downstream
+    // dispatch below happens inside user code — the variant hooks
+    // receive `&Router<EncodedMsg>` and the sample chooses the
+    // default peer via plain `router.send(...)`.  Source operators
+    // that need to route differently per `source_id` (e.g. fan out
+    // to distinct decoder pools) would call
     // `router.send_to(&decoder_for(&source_id), msg)` here instead.
     //
     // Note: we build the `VideoFrameProxy` on the **demuxer side**
     // via `make_decode_frame` + `EncodedMsg::Frame`.  Swap this for
-    // `Mp4DemuxerSource::default_on_packet()` if you want the
+    // `*DemuxerSource::default_on_packet()` if you want the
     // downstream decoder to own frame construction — the decoder
     // no longer tracks `VideoInfo` state, every
     // `EncodedMsg::Packet` carries it in-band instead.
-    let demux_src = Mp4DemuxerSource::builder(demux_name.clone())
-        .input(cli.input.to_string_lossy().into_owned())
-        .source_id(SOURCE_ID)
-        .downstream(decoder_name.clone())
-        .results(
-            Mp4DemuxerResults::builder()
-                .on_packet(|pkt, info, source_id, router, ctx| {
-                    if let Some(stats) = ctx.shared::<PipelineStats>() {
-                        stats.demux_packets.fetch_add(1, Ordering::Relaxed);
-                    }
-                    let frame = make_decode_frame(source_id, &pkt, info);
-                    router.send(EncodedMsg::Frame {
-                        frame,
-                        payload: Some(pkt.data),
-                    });
-                    Ok(())
-                })
-                .build(),
-        )
-        .build()?;
-    sys.register_source(demux_src)?;
+    //
+    // Dispatch on the resolved input variant to register the
+    // matching demuxer actor.  Both branches share the same
+    // `on_packet` body (envelope types are identical across the two
+    // demuxer templates); only the underlying GStreamer driver
+    // differs.
+    match cli.input.clone() {
+        InputSource::Path(path) => {
+            let demux_src = Mp4DemuxerSource::builder(demux_name.clone())
+                .input(path.to_string_lossy().into_owned())
+                .source_id(SOURCE_ID)
+                .downstream(decoder_name.clone())
+                .results(
+                    Mp4DemuxerResults::builder()
+                        .on_packet(|pkt, info, source_id, router, ctx| {
+                            if let Some(stats) = ctx.shared::<PipelineStats>() {
+                                stats.demux_packets.fetch_add(1, Ordering::Relaxed);
+                            }
+                            let frame = make_decode_frame(source_id, &pkt, info);
+                            router.send(EncodedMsg::Frame {
+                                frame,
+                                payload: Some(pkt.data),
+                            });
+                            Ok(())
+                        })
+                        .build(),
+                )
+                .build()?;
+            sys.register_source(demux_src)?;
+        }
+        InputSource::Uri(uri) => {
+            // `UriDemuxerSource` drives `urisourcebin` + `parsebin`
+            // under the hood and is suitable for file://, http://,
+            // rtsp://, rtmp://, hls://, … URIs.  Bin/source property
+            // maps are empty: defaults work for file:// and most
+            // public RTSP/HTTP sources.  Custom properties
+            // (e.g. `rtspsrc.latency`) can be plumbed through the
+            // builder's `.bin_properties(...)` /
+            // `.source_properties(...)` setters.
+            let demux_src = UriDemuxerSource::builder(demux_name.clone())
+                .input(uri)
+                .source_id(SOURCE_ID)
+                .downstream(decoder_name.clone())
+                .results(
+                    UriDemuxerResults::builder()
+                        .on_packet(|pkt, info, source_id, router, ctx| {
+                            if let Some(stats) = ctx.shared::<PipelineStats>() {
+                                stats.demux_packets.fetch_add(1, Ordering::Relaxed);
+                            }
+                            let frame = make_decode_frame(source_id, &pkt, info);
+                            router.send(EncodedMsg::Frame {
+                                frame,
+                                payload: Some(pkt.data),
+                            });
+                            Ok(())
+                        })
+                        .build(),
+                )
+                .build()?;
+            sys.register_source(demux_src)?;
+        }
+    }
 
     // ── Decoder actor ───────────────────────────────────────────────────
     //
@@ -650,18 +714,18 @@ pub fn run(cli: ResolvedCli) -> Result<()> {
 /// Custom [`ShutdownHandler`](savant_perception::shutdown::ShutdownHandler)
 /// policy for the `cars_tracking` sample.
 ///
-/// Pipeline shape: `Mp4Demuxer → Decoder → NvInfer → NvTracker →
-/// (Picasso → Mp4Muxer | Function terminus)`.  The demuxer finishing
-/// its input file is an **expected** event — it emits an in-band
-/// `SourceEos` sentinel that propagates through every stage to the
-/// terminus (Mp4Muxer or Function).  The terminus then
-/// self-terminates on that EOS (`Flow::Stop`), which is the real
-/// "pipeline drained" signal.
+/// Pipeline shape: `(Mp4Demuxer | UriDemuxer) → Decoder → NvInfer →
+/// NvTracker → (Picasso → Mp4Muxer | Function terminus)`.  Either
+/// demuxer finishing its input is an **expected** event — it emits
+/// an in-band `SourceEos` sentinel that propagates through every
+/// stage to the terminus (Mp4Muxer or Function).  The terminus
+/// then self-terminates on that EOS (`Flow::Stop`), which is the
+/// real "pipeline drained" signal.
 ///
 /// The policy therefore:
 ///
-/// * Ignores `StageExit { stage.kind == Mp4Demux }` — the demuxer
-///   is expected to exit first; wait for the terminus.
+/// * Ignores `StageExit { stage.kind == Mp4Demux | UriDemux }` —
+///   the demuxer is expected to exit first; wait for the terminus.
 /// * On any other `StageExit` (terminus drained, mid-pipeline
 ///   error, or a stage panic) broadcasts a `Shutdown { grace:
 ///   None }` immediately — no quiescence pause is needed because
@@ -672,7 +736,9 @@ fn cars_shutdown_handler(
     _ctx: &mut ShutdownCtx<'_>,
 ) -> Result<ShutdownAction> {
     match cause {
-        ShutdownCause::StageExit { stage } if stage.kind == StageKind::Mp4Demux => {
+        ShutdownCause::StageExit { stage }
+            if matches!(stage.kind, StageKind::Mp4Demux | StageKind::UriDemux) =>
+        {
             log::info!(
                 "[supervisor] {stage} exited naturally (end-of-input); \
                  waiting for terminus to drain before broadcasting Shutdown"
@@ -863,7 +929,7 @@ mod tests {
     #[test]
     fn run_rejects_missing_input() {
         let cli = ResolvedCli {
-            input: PathBuf::from("/definitely/does/not/exist.mp4"),
+            input: InputSource::Path(PathBuf::from("/definitely/does/not/exist.mp4")),
             output: Some(std::env::temp_dir().join("savant_perception_pipeline_out.mp4")),
             gpu: 0,
             conf: 0.25,
@@ -881,5 +947,20 @@ mod tests {
             err.to_string().contains("input file does not exist"),
             "unexpected error: {err:#}"
         );
+    }
+
+    /// Natural exit of the URI demuxer stage must be treated the
+    /// same as the MP4 demuxer: ignored so the terminus can drain
+    /// the in-band `SourceEos` before a broadcast fires.
+    #[test]
+    fn shutdown_handler_ignores_uri_demux_stage_exit() {
+        let stages: [StageName; 0] = [];
+        let history: [ShutdownCause; 0] = [];
+        let mut ctx = ShutdownCtx::fake(&stages, &history);
+        let cause = ShutdownCause::StageExit {
+            stage: StageName::unnamed(StageKind::UriDemux),
+        };
+        let action = cars_shutdown_handler(cause, &mut ctx).unwrap();
+        assert!(matches!(action, ShutdownAction::Ignore));
     }
 }

--- a/savant_perception/examples/cars_demo/cli.rs
+++ b/savant_perception/examples/cars_demo/cli.rs
@@ -7,6 +7,7 @@
 
 use anyhow::{bail, Result};
 use clap::Parser;
+use std::fmt;
 use std::path::{Path, PathBuf};
 
 /// Minimum allowed `--channel-cap`.  Keeps backpressure meaningful:
@@ -18,13 +19,26 @@ pub const MIN_CHANNEL_CAPACITY: usize = 2;
 #[derive(Debug, Clone, Parser)]
 #[command(
     name = "cars-demo",
-    about = "Streaming MP4 -> decode -> YOLO -> NvDCF -> draw -> encode -> MP4 pipeline."
+    about = "Streaming MP4/URI -> decode -> YOLO -> NvDCF -> draw -> encode -> MP4 pipeline."
 )]
 pub struct Cli {
-    /// Input MP4 file.  If the path is relative it is resolved against the
-    /// `savant_perception` crate manifest directory.
+    /// Input source.  Either:
+    ///
+    /// * a filesystem path to an MP4 (or any GStreamer-parsable
+    ///   container).  Relative paths are resolved against the
+    ///   `savant_perception` crate manifest directory; the path
+    ///   must exist.
+    /// * a URI (e.g. `file:///abs/path.mp4`, `http://host/a.m3u8`,
+    ///   `rtsp://cam/stream`, `rtmp://host/key`, …).  A URI is
+    ///   handed directly to the URI-based demuxer actor and the
+    ///   filesystem existence check is skipped.
+    ///
+    /// The dispatcher inside
+    /// [`crate::cars_tracking::pipeline::run`] picks the demuxer
+    /// actor (`Mp4Demuxer` vs `UriDemuxer`) based on which variant
+    /// this string resolves to.
     #[arg(long)]
-    pub input: PathBuf,
+    pub input: String,
 
     /// Output MP4 file.  Required unless [`Cli::no_picasso`] is set;
     /// when Picasso is disabled the pipeline produces no output file
@@ -95,18 +109,75 @@ pub struct Cli {
     pub no_picasso: bool,
 }
 
+/// Resolved input — either a filesystem path (handled by
+/// `Mp4DemuxerSource`) or a URI (handled by `UriDemuxerSource`).
+///
+/// The dispatcher inside
+/// [`crate::cars_tracking::pipeline::run`] branches on this
+/// variant to pick the demuxer actor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InputSource {
+    /// Absolute filesystem path, pre-validated to exist.
+    Path(PathBuf),
+    /// URI string (e.g. `rtsp://cam/stream`); handed to the URI
+    /// demuxer as-is.  No filesystem check is performed.
+    Uri(String),
+}
+
+impl fmt::Display for InputSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            InputSource::Path(p) => fmt::Display::fmt(&p.display(), f),
+            InputSource::Uri(u) => f.write_str(u),
+        }
+    }
+}
+
+/// Syntactic check for a URI-style input: a non-empty ASCII-alpha
+/// scheme followed by `://`.  Mirrors the `is_plausible_uri`
+/// helper used inside
+/// [`savant_gstreamer::uri_demuxer`].  Filesystem paths (even
+/// those containing `:` like Windows drive letters, though this
+/// example is Linux-only) do not match because they do not start
+/// with a scheme followed by `://`.
+fn input_looks_like_uri(s: &str) -> bool {
+    let Some((scheme, rest)) = s.split_once("://") else {
+        return false;
+    };
+    if scheme.is_empty() || rest.is_empty() {
+        return false;
+    }
+    let mut chars = scheme.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !first.is_ascii_alphabetic() {
+        return false;
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '-' || c == '.')
+}
+
 impl Cli {
-    /// Resolve the input path (relative paths are taken to be relative to
-    /// the `savant_perception` crate manifest directory) and validate that it
-    /// points to an existing file.
+    /// Resolve the input to either a validated filesystem [`PathBuf`]
+    /// or an unmodified URI string.
     ///
-    /// Returns the absolute, validated input path on success.
-    pub fn resolved_input(&self) -> Result<PathBuf> {
+    /// * URI inputs (`scheme://…`) are returned as
+    ///   [`InputSource::Uri`] without any filesystem check — the
+    ///   URI-based demuxer will surface unreachable hosts / bad
+    ///   schemes as pipeline errors once it starts.
+    /// * Filesystem paths are resolved against `CARGO_MANIFEST_DIR`
+    ///   when relative and the result must exist on disk.
+    pub fn resolved_input(&self) -> Result<InputSource> {
+        if input_looks_like_uri(&self.input) {
+            return Ok(InputSource::Uri(self.input.clone()));
+        }
+
+        let raw = PathBuf::from(&self.input);
         let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        let path = if self.input.is_absolute() {
-            self.input.clone()
+        let path = if raw.is_absolute() {
+            raw
         } else {
-            manifest_dir.join(&self.input)
+            manifest_dir.join(&raw)
         };
 
         if !path.exists() {
@@ -114,13 +185,14 @@ impl Cli {
                 "input file does not exist: {}\n\
                  Place the clip manually, e.g.:\n    \
                  curl -L -o {input} \\\n        \
-                 https://eu-central-1.linodeobjects.com/savant-data/demo/ny_city_center.mov",
+                 https://eu-central-1.linodeobjects.com/savant-data/demo/ny_city_center.mov\n\
+                 Or pass a URI like rtsp://cam/stream (no filesystem check).",
                 path.display(),
-                input = self.input.display()
+                input = self.input
             );
         }
 
-        Ok(path)
+        Ok(InputSource::Path(path))
     }
 
     /// Resolve the output path against the picasso mode.
@@ -228,12 +300,15 @@ impl Cli {
     }
 }
 
-/// Fully-validated, absolute paths + numeric knobs ready to be handed to
+/// Fully-validated input + output + numeric knobs ready to be handed to
 /// [`crate::cars_tracking::pipeline::run`].
 #[derive(Debug, Clone)]
 pub struct ResolvedCli {
-    /// Absolute path to the input MP4 file.
-    pub input: PathBuf,
+    /// Resolved input source — either a validated filesystem path
+    /// ([`InputSource::Path`]) or a URI ([`InputSource::Uri`]).
+    /// The pipeline dispatches to `Mp4DemuxerSource` or
+    /// `UriDemuxerSource` based on this variant.
+    pub input: InputSource,
     /// Absolute path to the output MP4 file.  `None` when Picasso
     /// is excluded via `--no-picasso` — no file is written in that
     /// mode.  Always `Some` when [`Self::picasso_enabled`] is
@@ -277,8 +352,9 @@ pub struct ResolvedCli {
 }
 
 impl ResolvedCli {
-    /// Borrow the input path.
-    pub fn input(&self) -> &Path {
+    /// Borrow the resolved input.  Implements [`fmt::Display`] so
+    /// callers can log it uniformly regardless of variant.
+    pub fn input(&self) -> &InputSource {
         &self.input
     }
 
@@ -395,6 +471,10 @@ mod tests {
         assert!(!resolved.picasso_enabled);
         assert!(!resolved.draw_enabled);
         assert!(resolved.output.is_none());
+        assert!(
+            matches!(resolved.input, InputSource::Path(_)),
+            "filesystem input resolves to InputSource::Path"
+        );
     }
 
     /// Without `--no-picasso`, omitting `--output` is a hard error:
@@ -496,5 +576,94 @@ mod tests {
         assert!(resolved.picasso_enabled);
         assert!(!resolved.output_is_null);
         assert!(resolved.output.is_some());
+    }
+
+    /// `input_looks_like_uri` recognises common GStreamer URI
+    /// schemes and rejects bare filesystem paths.
+    #[test]
+    fn input_uri_detection_covers_common_schemes() {
+        assert!(input_looks_like_uri("file:///tmp/x.mp4"));
+        assert!(input_looks_like_uri("http://host/a.m3u8"));
+        assert!(input_looks_like_uri("https://host/a.m3u8"));
+        assert!(input_looks_like_uri("rtsp://cam/stream"));
+        assert!(input_looks_like_uri("rtsps://cam/stream"));
+        assert!(input_looks_like_uri("rtmp://host/app/key"));
+        assert!(input_looks_like_uri("hls+http://host/a.m3u8"));
+
+        assert!(!input_looks_like_uri("some.mov"));
+        assert!(!input_looks_like_uri("/abs/path.mov"));
+        assert!(!input_looks_like_uri("relative/path.mov"));
+        assert!(!input_looks_like_uri("://nohost"));
+        assert!(!input_looks_like_uri(""));
+        assert!(!input_looks_like_uri("9scheme://host"));
+    }
+
+    /// A URI input resolves to [`InputSource::Uri`] without touching
+    /// the filesystem — even when the URI names a path that clearly
+    /// does not exist.
+    #[test]
+    fn uri_input_skips_filesystem_check() {
+        for uri in [
+            "rtsp://cam/stream",
+            "http://example.com/a.m3u8",
+            "file:///definitely/does/not/exist.mp4",
+        ] {
+            let cli =
+                Cli::try_parse_from(["cars-demo", "--input", uri, "--output", "/tmp/out.mp4"])
+                    .unwrap();
+            let input = cli
+                .resolved_input()
+                .unwrap_or_else(|e| panic!("URI {uri} must resolve without fs check, got: {e:#}"));
+            match input {
+                InputSource::Uri(u) => assert_eq!(u, uri),
+                other => panic!("expected Uri, got {other:?}"),
+            }
+        }
+    }
+
+    /// `resolve` propagates the `InputSource::Uri` variant end-to-end
+    /// into `ResolvedCli` — the pipeline dispatcher reads this
+    /// variant to pick the demuxer actor.
+    #[test]
+    fn resolve_preserves_uri_variant() {
+        let cli = Cli::try_parse_from([
+            "cars-demo",
+            "--input",
+            "rtsp://cam/stream",
+            "--output",
+            "/tmp/out.mp4",
+        ])
+        .unwrap();
+        let resolved = cli.resolve().expect("URI input must resolve");
+        match &resolved.input {
+            InputSource::Uri(u) => assert_eq!(u, "rtsp://cam/stream"),
+            other => panic!("expected Uri, got {other:?}"),
+        }
+        assert_eq!(resolved.input().to_string(), "rtsp://cam/stream");
+    }
+
+    /// Path input round-trips through `resolved_input` as
+    /// [`InputSource::Path`] with an absolute path.
+    #[test]
+    fn path_input_resolves_to_absolute_path() {
+        let cli = Cli::try_parse_from([
+            "cars-demo",
+            "--input",
+            // Relative to CARGO_MANIFEST_DIR.
+            "examples/cars_demo/cars_tracking.rs",
+            "--output",
+            "/tmp/out.mp4",
+        ])
+        .unwrap();
+        let input = cli
+            .resolved_input()
+            .expect("existing relative path resolves");
+        match input {
+            InputSource::Path(p) => {
+                assert!(p.is_absolute(), "relative path must be made absolute");
+                assert!(p.exists(), "resolved path must exist on disk");
+            }
+            other => panic!("expected Path, got {other:?}"),
+        }
     }
 }

--- a/savant_perception/examples/cars_demo/cli.rs
+++ b/savant_perception/examples/cars_demo/cli.rs
@@ -7,6 +7,7 @@
 
 use anyhow::{bail, Result};
 use clap::Parser;
+use savant_gstreamer::uri_demuxer::is_plausible_uri;
 use std::fmt;
 use std::path::{Path, PathBuf};
 
@@ -133,30 +134,6 @@ impl fmt::Display for InputSource {
     }
 }
 
-/// Syntactic check for a URI-style input: a non-empty ASCII-alpha
-/// scheme followed by `://`.  Mirrors the `is_plausible_uri`
-/// helper used inside
-/// [`savant_gstreamer::uri_demuxer`].  Filesystem paths (even
-/// those containing `:` like Windows drive letters, though this
-/// example is Linux-only) do not match because they do not start
-/// with a scheme followed by `://`.
-fn input_looks_like_uri(s: &str) -> bool {
-    let Some((scheme, rest)) = s.split_once("://") else {
-        return false;
-    };
-    if scheme.is_empty() || rest.is_empty() {
-        return false;
-    }
-    let mut chars = scheme.chars();
-    let Some(first) = chars.next() else {
-        return false;
-    };
-    if !first.is_ascii_alphabetic() {
-        return false;
-    }
-    chars.all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '-' || c == '.')
-}
-
 impl Cli {
     /// Resolve the input to either a validated filesystem [`PathBuf`]
     /// or an unmodified URI string.
@@ -168,7 +145,7 @@ impl Cli {
     /// * Filesystem paths are resolved against `CARGO_MANIFEST_DIR`
     ///   when relative and the result must exist on disk.
     pub fn resolved_input(&self) -> Result<InputSource> {
-        if input_looks_like_uri(&self.input) {
+        if is_plausible_uri(&self.input) {
             return Ok(InputSource::Uri(self.input.clone()));
         }
 
@@ -578,24 +555,24 @@ mod tests {
         assert!(resolved.output.is_some());
     }
 
-    /// `input_looks_like_uri` recognises common GStreamer URI
+    /// `is_plausible_uri` recognises common GStreamer URI
     /// schemes and rejects bare filesystem paths.
     #[test]
     fn input_uri_detection_covers_common_schemes() {
-        assert!(input_looks_like_uri("file:///tmp/x.mp4"));
-        assert!(input_looks_like_uri("http://host/a.m3u8"));
-        assert!(input_looks_like_uri("https://host/a.m3u8"));
-        assert!(input_looks_like_uri("rtsp://cam/stream"));
-        assert!(input_looks_like_uri("rtsps://cam/stream"));
-        assert!(input_looks_like_uri("rtmp://host/app/key"));
-        assert!(input_looks_like_uri("hls+http://host/a.m3u8"));
+        assert!(is_plausible_uri("file:///tmp/x.mp4"));
+        assert!(is_plausible_uri("http://host/a.m3u8"));
+        assert!(is_plausible_uri("https://host/a.m3u8"));
+        assert!(is_plausible_uri("rtsp://cam/stream"));
+        assert!(is_plausible_uri("rtsps://cam/stream"));
+        assert!(is_plausible_uri("rtmp://host/app/key"));
+        assert!(is_plausible_uri("hls+http://host/a.m3u8"));
 
-        assert!(!input_looks_like_uri("some.mov"));
-        assert!(!input_looks_like_uri("/abs/path.mov"));
-        assert!(!input_looks_like_uri("relative/path.mov"));
-        assert!(!input_looks_like_uri("://nohost"));
-        assert!(!input_looks_like_uri(""));
-        assert!(!input_looks_like_uri("9scheme://host"));
+        assert!(!is_plausible_uri("some.mov"));
+        assert!(!is_plausible_uri("/abs/path.mov"));
+        assert!(!is_plausible_uri("relative/path.mov"));
+        assert!(!is_plausible_uri("://nohost"));
+        assert!(!is_plausible_uri(""));
+        assert!(!is_plausible_uri("9scheme://host"));
     }
 
     /// A URI input resolves to [`InputSource::Uri`] without touching

--- a/savant_perception/examples/cars_demo/main.rs
+++ b/savant_perception/examples/cars_demo/main.rs
@@ -37,7 +37,7 @@ fn main() -> Result<()> {
     let resolved = cli.resolve()?;
     log::info!(
         "cars-demo: input={} output={} gpu={} conf={} iou={} channel_cap={} fps={}/{} picasso_enabled={} draw_enabled={} debug={}",
-        resolved.input().display(),
+        resolved.input(),
         resolved
             .output()
             .map(|p| p.display().to_string())

--- a/savant_perception/src/supervisor.rs
+++ b/savant_perception/src/supervisor.rs
@@ -57,6 +57,12 @@ use std::fmt;
 pub enum StageKind {
     /// [`mp4_demux`](super::pipeline::mp4_demux) actor — `Mp4Demuxer` wrapper.
     Mp4Demux,
+    /// URI demuxer source — `UriDemuxer` wrapper around
+    /// `urisourcebin` / `parsebin` for file://, http://, rtsp://,
+    /// rtmp://, hls://, … inputs.  Shares the
+    /// "natural exit is expected" policy with `Mp4Demux` in
+    /// sample shutdown handlers.
+    UriDemux,
     /// [`decoder`](super::pipeline::decoder) actor — `FlexibleDecoderPool` wrapper.
     Decoder,
     /// [`infer`](super::pipeline::infer) actor — nvinfer batching operator.
@@ -81,6 +87,7 @@ impl StageKind {
     pub const fn as_str(&self) -> &'static str {
         match self {
             StageKind::Mp4Demux => "mp4_demux",
+            StageKind::UriDemux => "uri_demux",
             StageKind::Decoder => "decoder",
             StageKind::Infer => "infer",
             StageKind::Tracker => "tracker",
@@ -319,6 +326,7 @@ mod tests {
     fn stage_kind_as_str_covers_every_variant() {
         for (kind, expected) in [
             (StageKind::Mp4Demux, "mp4_demux"),
+            (StageKind::UriDemux, "uri_demux"),
             (StageKind::Decoder, "decoder"),
             (StageKind::Infer, "infer"),
             (StageKind::Tracker, "tracker"),

--- a/savant_perception/src/templates.rs
+++ b/savant_perception/src/templates.rs
@@ -35,6 +35,7 @@ pub mod mp4_muxer;
 pub mod nvinfer;
 pub mod nvtracker;
 pub mod picasso;
+pub mod uri_demuxer;
 
 pub use bitstream_function::{
     BitstreamFunction, BitstreamFunctionBuilder, BitstreamFunctionCommon,
@@ -75,4 +76,8 @@ pub use picasso::{
     DeliveryHook as PicassoDeliveryHook, OnStoppingHook as PicassoOnStoppingHook, Picasso,
     PicassoBuilder, PicassoCommon, PicassoCommonBuilder, PicassoEngineFactory, PicassoInbox,
     PicassoInboxBuilder, SourceSpecFactory, SrcRectProvider,
+};
+pub use uri_demuxer::{
+    OnStoppingHook as UriDemuxerOnStoppingHook, UriDemuxerBuilder, UriDemuxerCommon,
+    UriDemuxerCommonBuilder, UriDemuxerResults, UriDemuxerResultsBuilder, UriDemuxerSource,
 };

--- a/savant_perception/src/templates/decoder.rs
+++ b/savant_perception/src/templates/decoder.rs
@@ -272,6 +272,34 @@ pub type OnDecoderErrorHook = Arc<
     dyn Fn(&DecoderError, &Router<PipelineMsg>, &HookCtx) -> ErrorAction + Send + Sync + 'static,
 >;
 
+/// Hook fired for [`FlexibleDecoderOutput::Restarted`] — emitted when the
+/// underlying [`FlexibleDecoder`](deepstream_inputs::FlexibleDecoder)
+/// transparently restarted after the [`NvDecoder`] worker died (typically
+/// because the [`GstPipeline`](savant_gstreamer::pipeline::GstPipeline)
+/// watchdog tripped on stuck in-flight buffers).
+///
+/// Receives the `source_id` of the affected decoder, a human-readable
+/// reason, the number of in-flight frames lost during the restart, the
+/// router for optional downstream signalling, and the [`HookCtx`].  Runs
+/// on the pool's output callback thread.
+///
+/// Returns `Result<Flow>` so the hook can choose to keep running
+/// (`Ok(Flow::Cont)`) or escalate the restart into a cooperative pipeline
+/// stop (`Ok(Flow::Stop)` / `Err(_)`).  As with
+/// [`OnDecoderSourceEosHook`], a stop request translates into the
+/// dispatcher calling [`HookCtx::request_stop`] and aborting the default
+/// sink — the actor observes the cooperative intent on its next tick.
+///
+/// The default ([`Decoder::default_on_decoder_restart`]) is purely a
+/// `warn!` log line and `Ok(Flow::Cont)`, so transient watchdog-induced
+/// restarts do not stop the pipeline by themselves.
+pub type OnDecoderRestartHook = Arc<
+    dyn Fn(&str, &str, usize, &Router<PipelineMsg>, &HookCtx) -> Result<Flow>
+        + Send
+        + Sync
+        + 'static,
+>;
+
 /// User shutdown hook invoked from [`Actor::stopping`] *after* the
 /// template's built-in cleanup (guarded
 /// [`FlexibleDecoderPool::graceful_shutdown`]) has completed.
@@ -411,6 +439,36 @@ impl Decoder {
         |err, _router, ctx| {
             log::error!("[{}] decoder error: {err}", ctx.own_name());
             ErrorAction::LogAndContinue
+        }
+    }
+
+    /// Default `on_decoder_restart` logger — emits a single `warn!` line
+    /// reporting the affected `source_id`, the human-readable reason,
+    /// and the number of in-flight frames lost, prefixed by the stage
+    /// name pulled from the [`HookCtx`], and returns `Ok(Flow::Cont)`.
+    ///
+    /// Watchdog-induced restarts are typically transient (the underlying
+    /// [`FlexibleDecoder`](deepstream_inputs::FlexibleDecoder) re-runs
+    /// detection / activation for the next packet automatically), so the
+    /// default keeps the pipeline running.  Override to return
+    /// `Ok(Flow::Stop)` / `Err(_)` when a restart on this stage should
+    /// tear the pipeline down — for example:
+    ///
+    /// ```ignore
+    /// .on_decoder_restart(|sid, reason, lost, _r, _ctx| {
+    ///     log::error!("decoder {sid} restarted ({lost} frames lost): {reason} - aborting");
+    ///     Ok(Flow::Stop)
+    /// })
+    /// ```
+    pub fn default_on_decoder_restart(
+    ) -> impl Fn(&str, &str, usize, &Router<PipelineMsg>, &HookCtx) -> Result<Flow> + Send + Sync + 'static
+    {
+        |source_id, reason, lost_frames, _router, ctx| {
+            log::warn!(
+                "[{}] decoder restart: source_id={source_id} lost {lost_frames} in-flight frame(s); reason={reason}",
+                ctx.own_name()
+            );
+            Ok(Flow::Cont)
         }
     }
 
@@ -605,6 +663,7 @@ pub struct DecoderResults {
     on_orphan_frame: OnOrphanFrameHook,
     on_decoder_event: OnDecoderEventHook,
     on_decoder_error: OnDecoderErrorHook,
+    on_decoder_restart: OnDecoderRestartHook,
 }
 
 impl DecoderResults {
@@ -630,6 +689,7 @@ pub struct DecoderResultsBuilder {
     on_orphan_frame: Option<OnOrphanFrameHook>,
     on_decoder_event: Option<OnDecoderEventHook>,
     on_decoder_error: Option<OnDecoderErrorHook>,
+    on_decoder_restart: Option<OnDecoderRestartHook>,
 }
 
 impl DecoderResultsBuilder {
@@ -644,6 +704,7 @@ impl DecoderResultsBuilder {
             on_orphan_frame: None,
             on_decoder_event: None,
             on_decoder_error: None,
+            on_decoder_restart: None,
         }
     }
 
@@ -732,6 +793,23 @@ impl DecoderResultsBuilder {
         self
     }
 
+    /// Override the `on_decoder_restart` hook — fired for
+    /// [`FlexibleDecoderOutput::Restarted`].  Returns `Result<Flow>`;
+    /// the default ([`Decoder::default_on_decoder_restart`]) logs at
+    /// `warn!` and returns `Ok(Flow::Cont)` so the pipeline keeps
+    /// running.  Return `Ok(Flow::Stop)` / `Err(_)` to translate a
+    /// watchdog-induced restart into a cooperative pipeline stop.
+    pub fn on_decoder_restart<F>(mut self, f: F) -> Self
+    where
+        F: Fn(&str, &str, usize, &Router<PipelineMsg>, &HookCtx) -> Result<Flow>
+            + Send
+            + Sync
+            + 'static,
+    {
+        self.on_decoder_restart = Some(Arc::new(f));
+        self
+    }
+
     /// Finalise the bundle, substituting defaults for every omitted
     /// setter.
     pub fn build(self) -> DecoderResults {
@@ -743,6 +821,7 @@ impl DecoderResultsBuilder {
             on_orphan_frame,
             on_decoder_event,
             on_decoder_error,
+            on_decoder_restart,
         } = self;
         DecoderResults {
             on_frame: on_frame.unwrap_or_else(|| Arc::new(Decoder::default_on_frame())),
@@ -757,6 +836,8 @@ impl DecoderResultsBuilder {
                 .unwrap_or_else(|| Arc::new(Decoder::default_on_decoder_event())),
             on_decoder_error: on_decoder_error
                 .unwrap_or_else(|| Arc::new(Decoder::default_on_decoder_error())),
+            on_decoder_restart: on_decoder_restart
+                .unwrap_or_else(|| Arc::new(Decoder::default_on_decoder_restart())),
         }
     }
 }
@@ -1032,6 +1113,7 @@ impl DecoderBuilder {
             on_orphan_frame,
             on_decoder_event,
             on_decoder_error,
+            on_decoder_restart,
         } = results.unwrap_or_default();
         let DecoderCommon {
             poll_timeout,
@@ -1045,6 +1127,7 @@ impl DecoderBuilder {
             on_orphan_frame,
             on_decoder_event,
             on_decoder_error,
+            on_decoder_restart,
         };
         Ok(ActorBuilder::new(name.clone(), capacity)
             .poll_timeout(poll_timeout)
@@ -1085,6 +1168,7 @@ struct VariantHooks {
     on_orphan_frame: OnOrphanFrameHook,
     on_decoder_event: OnDecoderEventHook,
     on_decoder_error: OnDecoderErrorHook,
+    on_decoder_restart: OnDecoderRestartHook,
 }
 
 /// Build the [`FlexibleDecoderPool`] with a callback that dispatches
@@ -1162,6 +1246,31 @@ fn build_pool(
                     }
                 }
                 ErrorAction::LogAndContinue | ErrorAction::Swallow => {}
+            }
+        }
+        FlexibleDecoderOutput::Restarted {
+            source_id,
+            reason,
+            lost_frames,
+        } => {
+            match (hooks.on_decoder_restart)(source_id, reason, *lost_frames, &router, &hook_ctx) {
+                Ok(Flow::Cont) => {}
+                Ok(Flow::Stop) => {
+                    log::info!(
+                        "[{owner_cb}/cb] on_decoder_restart requested stop; cooperatively shutting down"
+                    );
+                    hook_ctx.request_stop();
+                    if let Some(sink) = router.default_sink() {
+                        sink.abort();
+                    }
+                }
+                Err(e) => {
+                    log::error!("[{owner_cb}/cb] on_decoder_restart returned error: {e}");
+                    hook_ctx.request_stop();
+                    if let Some(sink) = router.default_sink() {
+                        sink.abort();
+                    }
+                }
             }
         }
     };
@@ -1294,6 +1403,7 @@ mod tests {
                     .on_orphan_frame(|_, _, _| {})
                     .on_decoder_event(|_, _, _| {})
                     .on_decoder_error(|_, _, _| ErrorAction::LogAndContinue)
+                    .on_decoder_restart(|_, _, _, _, _| Ok(Flow::Cont))
                     .build(),
             )
             .common(
@@ -1326,6 +1436,7 @@ mod tests {
                     .on_orphan_frame(Decoder::default_on_orphan_frame())
                     .on_decoder_event(Decoder::default_on_decoder_event())
                     .on_decoder_error(Decoder::default_on_decoder_error())
+                    .on_decoder_restart(Decoder::default_on_decoder_restart())
                     .build(),
             )
             .common(
@@ -1469,6 +1580,75 @@ mod tests {
                 }
             }
             ErrorAction::LogAndContinue | ErrorAction::Swallow => {}
+        }
+        assert!(stop_flag.load(Ordering::SeqCst));
+    }
+
+    /// `default_on_decoder_restart` is log-only — it returns
+    /// `Ok(Flow::Cont)` and must not route anything downstream so
+    /// transient watchdog-induced restarts do not crash the pipeline.
+    #[test]
+    fn default_on_decoder_restart_does_not_route() {
+        let hook = Decoder::default_on_decoder_restart();
+        let (router, rx) = router_with_default_peer();
+        let ctx = test_hook_ctx();
+        let flow = hook("cam-1", "worker thread exited", 8, &router, &ctx).expect("no error");
+        assert!(matches!(flow, Flow::Cont));
+        assert!(rx.try_recv().is_err(), "restarts must not be routed");
+    }
+
+    /// A user `on_decoder_restart` returning `Ok(Flow::Stop)` flips the
+    /// shared stop flag, mirroring the
+    /// [`on_decoder_error_fatal_requests_stop`] contract.
+    #[test]
+    fn on_decoder_restart_stop_requests_stop() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        let ctx = HookCtx::new(
+            StageName::unnamed(StageKind::Decoder),
+            Arc::new(Registry::new()),
+            Arc::new(crate::shared::SharedStore::new()),
+            stop_flag.clone(),
+        );
+        let hook: OnDecoderRestartHook =
+            Arc::new(|_sid, _reason, _lost, _router, _ctx| Ok(Flow::Stop));
+        let (router, _rx) = router_with_default_peer();
+        match hook("cam-1", "worker thread exited", 4, &router, &ctx).expect("hook ok") {
+            Flow::Cont => {}
+            Flow::Stop => {
+                ctx.request_stop();
+                if let Some(sink) = router.default_sink() {
+                    sink.abort();
+                }
+            }
+        }
+        assert!(stop_flag.load(Ordering::SeqCst));
+    }
+
+    /// A user `on_decoder_restart` returning `Err(_)` likewise flips
+    /// the shared stop flag — the dispatcher treats it identically to
+    /// `Ok(Flow::Stop)`.
+    #[test]
+    fn on_decoder_restart_err_requests_stop() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        let ctx = HookCtx::new(
+            StageName::unnamed(StageKind::Decoder),
+            Arc::new(Registry::new()),
+            Arc::new(crate::shared::SharedStore::new()),
+            stop_flag.clone(),
+        );
+        let hook: OnDecoderRestartHook =
+            Arc::new(|_sid, _reason, _lost, _router, _ctx| Err(anyhow!("boom")));
+        let (router, _rx) = router_with_default_peer();
+        match hook("cam-1", "worker thread exited", 0, &router, &ctx) {
+            Ok(Flow::Cont) => {}
+            Ok(Flow::Stop) | Err(_) => {
+                ctx.request_stop();
+                if let Some(sink) = router.default_sink() {
+                    sink.abort();
+                }
+            }
         }
         assert!(stop_flag.load(Ordering::SeqCst));
     }

--- a/savant_perception/src/templates/uri_demuxer.rs
+++ b/savant_perception/src/templates/uri_demuxer.rs
@@ -1,34 +1,43 @@
-//! [`Mp4DemuxerSource`] — an MP4 (and any other GStreamer-parsable
-//! container) source that surfaces every demuxed output variant to
-//! user code, along with the stage's [`Router<EncodedMsg>`].
+//! [`UriDemuxerSource`] — a URI-based source (file://, http://,
+//! rtsp://, rtmp://, hls://, …) that surfaces every demuxed output
+//! variant to user code, along with the stage's
+//! [`Router<EncodedMsg>`].
 //!
-//! Direct replacement for
-//! `cars_tracking/pipeline/mp4_demux.rs` — the template hides:
+//! API-symmetric with
+//! [`Mp4DemuxerSource`](super::mp4_demuxer::Mp4DemuxerSource): the
+//! two templates differ only in the underlying demuxer driver
+//! ([`savant_gstreamer::uri_demuxer::UriDemuxer`] vs
+//! [`savant_gstreamer::mp4_demuxer::Mp4Demuxer`]) and in the error
+//! type surfaced by the `on_error` classifier. Every envelope
+//! variant ([`EncodedMsg::StreamInfo`], [`EncodedMsg::Packet`],
+//! [`EncodedMsg::Frame`], [`EncodedMsg::SourceEos`]) is identical;
+//! `DemuxedPacket` / `VideoInfo` / `VideoCodec` are shared types
+//! (see [`savant_gstreamer::demux`]).
 //!
-//! * `Arc<AtomicBool>` abort flag (becomes [`SourceContext::is_stopping`]).
-//! * Manual exit-guard wiring (the framework installs it around
-//!   [`Source::run`]).
-//! * The first-error latch (still present, but hidden in the
-//!   template body).
+//! Compared to [`Mp4DemuxerSource`](super::mp4_demuxer::Mp4DemuxerSource),
+//! [`UriDemuxerSource`] additionally exposes:
 //!
-//! The template itself never calls `router.send` — **every send
-//! site for this stage lives in user code**.  That lets source-side
-//! routing (for instance "pick a decoder pool by source_id" or
-//! "broadcast the same packet to multiple decoders via
-//! `router.send_to(&peer, msg)`") stay visible at the callsite.
-//!
-//! The user-facing surface is a fluent builder with grouped
-//! hook bundles — [`Mp4DemuxerResults`] for the four demuxed-output
-//! variants and [`Mp4DemuxerCommon`] for the user shutdown hook:
+//! * `.parsed(bool)` — forwarded to
+//!   [`UriDemuxerConfig::with_parsed`]. Defaults to `true`.
+//! * `.bin_properties(Vec<(String, PropertyValue)>)` — applied to
+//!   the top-level `urisourcebin` element
+//!   (e.g. `buffer-size`, `use-buffering`, `connection-speed`).
+//! * `.source_properties(Vec<(String, PropertyValue)>)` — applied
+//!   to the dynamically-created inner source element via the
+//!   `source-setup` signal (e.g. `rtspsrc.latency`,
+//!   `souphttpsrc.user-agent`).
 //!
 //! ```ignore
 //! sys.register_source(
-//!     Mp4DemuxerSource::builder(StageName::unnamed(StageKind::Mp4Demux))
-//!         .input(input_path)
+//!     UriDemuxerSource::builder(StageName::unnamed(StageKind::UriDemux))
+//!         .input("rtsp://cam/stream")
 //!         .source_id("cam1")
 //!         .downstream(StageName::unnamed(StageKind::Decoder))
+//!         .source_properties(vec![
+//!             ("latency".into(), PropertyValue::U64(200)),
+//!         ])
 //!         .results(
-//!             Mp4DemuxerResults::builder()
+//!             UriDemuxerResults::builder()
 //!                 .on_packet(|pkt, info, source_id, router, _ctx| {
 //!                     router.send(EncodedMsg::Packet {
 //!                         source_id: source_id.to_string(),
@@ -45,77 +54,24 @@
 //!
 //! # Default forwarders
 //!
-//! For the common "forward this variant to the default peer
-//! unchanged" case, [`Mp4DemuxerSource`] ships four ready-made hook
-//! closures:
+//! Mirror the mp4 template:
 //!
-//! * [`Mp4DemuxerSource::default_on_stream_info`] — sends
-//!   [`EncodedMsg::StreamInfo`](crate::envelopes::EncodedMsg::StreamInfo).
-//! * [`Mp4DemuxerSource::default_on_packet`] — sends
-//!   [`EncodedMsg::Packet`](crate::envelopes::EncodedMsg::Packet).
-//!   Use when the downstream decoder owns frame construction.
-//! * [`Mp4DemuxerSource::default_on_packet_as_frame`] — constructs
-//!   a [`VideoFrameProxy`](savant_core::primitives::frame::VideoFrameProxy)
-//!   on the demuxer side (via
-//!   [`make_decode_frame`](super::decoder::make_decode_frame)) and
-//!   sends
-//!   [`EncodedMsg::Frame`](crate::envelopes::EncodedMsg::Frame).
-//!   Use when you want upstream frame construction so the decoder
-//!   can stay stateless w.r.t. [`VideoInfo`].
-//! * [`Mp4DemuxerSource::default_on_source_eos`] — sends
-//!   [`EncodedMsg::SourceEos`](crate::envelopes::EncodedMsg::SourceEos).
-//!
-//! Pick exactly one of `default_on_packet` / `default_on_packet_as_frame`
-//! per source — the two differ only in whether the
-//! [`VideoFrameProxy`](savant_core::primitives::frame::VideoFrameProxy)
-//! is built upstream or downstream.
-//!
-//! Because each one is an associated function that returns an owned
-//! closure, the send still lives in user code (the user names the
-//! forwarder at the call site) — the template just factors out the
-//! one-line body.  Reach for a hand-written closure when you need
-//! to observe the variant, suppress it, or route via
-//! `router.send_to(&peer, msg)`.
+//! * [`UriDemuxerSource::default_on_stream_info`]
+//! * [`UriDemuxerSource::default_on_packet`]
+//! * [`UriDemuxerSource::default_on_packet_as_frame`]
+//! * [`UriDemuxerSource::default_on_source_eos`]
+//! * [`UriDemuxerSource::default_on_error`]
+//! * [`UriDemuxerSource::default_stopping`]
 //!
 //! ## Always-set invariant
 //!
-//! [`Mp4DemuxerSource`] stores its four variant hooks
-//! (`on_stream_info`, `on_packet`, `on_source_eos`, `on_error`) as
-//! non-`Option` fields.  Omitting a setter on
-//! [`Mp4DemuxerBuilder`] is **equivalent to calling it with the
-//! matching** `Mp4DemuxerSource::default_on_*` forwarder — the
-//! builder substitutes the default in [`Mp4DemuxerBuilder::build`]
-//! before constructing the source.  In particular:
-//!
-//! * `on_packet` defaults to
-//!   [`Mp4DemuxerSource::default_on_packet_as_frame`] (upstream
-//!   frame construction).  Call `.on_packet(...)` with a custom
-//!   closure to opt into any other policy.
-//! * `on_error` defaults to
-//!   [`Mp4DemuxerSource::default_on_error`], which returns
-//!   [`ErrorAction::Fatal`] for every
-//!   [`Mp4DemuxerError`] — matching the legacy "first error
-//!   latches and aborts the sink" behaviour.
-//!
-//! There is therefore no runtime code path in which a demuxer
-//! variant is dropped on the floor because the corresponding setter
-//! was not called.  The builder's internal `Option<Hook>` fields
-//! exist purely as a "was the setter called?" marker and are
-//! collapsed to non-`Option` before the source is constructed.
-//!
-//! ```ignore
-//! Mp4DemuxerSource::builder(name)
-//!     .input(path).source_id("cam1")
-//!     .downstream(decoder_name)
-//!     .results(
-//!         Mp4DemuxerResults::builder()
-//!             .on_stream_info(Mp4DemuxerSource::default_on_stream_info())
-//!             .on_packet(Mp4DemuxerSource::default_on_packet_as_frame())
-//!             .on_source_eos(Mp4DemuxerSource::default_on_source_eos())
-//!             .build(),
-//!     )
-//!     .build()?;
-//! ```
+//! As with [`Mp4DemuxerSource`](super::mp4_demuxer::Mp4DemuxerSource),
+//! the four variant hooks (`on_stream_info`, `on_packet`,
+//! `on_source_eos`, `on_error`) are stored as non-`Option` fields.
+//! Omitted setters on [`UriDemuxerBuilder`] are substituted with the
+//! matching `UriDemuxerSource::default_on_*` in
+//! [`UriDemuxerBuilder::build`] — so no runtime code path can drop a
+//! demuxer variant on the floor.
 
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -123,9 +79,13 @@ use std::time::Duration;
 
 use anyhow::{anyhow, bail, Result};
 use parking_lot::Mutex;
-use savant_gstreamer::mp4_demuxer::{
-    DemuxedPacket, Mp4Demuxer, Mp4DemuxerError, Mp4DemuxerOutput, VideoInfo,
+use savant_gstreamer::uri_demuxer::{
+    PropertyValue, UriDemuxer, UriDemuxerConfig, UriDemuxerError, UriDemuxerOutput,
 };
+// `DemuxedPacket` and `VideoInfo` are shared between demuxers —
+// import them through the mp4 template's re-exports so both
+// templates stay pinned to the same type identity.
+use savant_gstreamer::mp4_demuxer::{DemuxedPacket, VideoInfo};
 
 use crate::envelopes::EncodedMsg;
 use crate::router::Router;
@@ -143,7 +103,7 @@ pub type OnStreamInfoHook =
 
 /// Closure type for `on_packet` — receives each demuxed access
 /// unit, the stream-level [`VideoInfo`] (as seen in the preceding
-/// [`Mp4DemuxerOutput::StreamInfo`]), the `source_id`, and the
+/// [`UriDemuxerOutput::StreamInfo`]), the `source_id`, and the
 /// router.  Typical use:
 /// `router.send(EncodedMsg::Packet { source_id: source_id.into(), info: *info, packet: pkt })`.
 ///
@@ -153,7 +113,7 @@ pub type OnStreamInfoHook =
 /// [`Decoder`](super::decoder::Decoder)) never have to
 /// maintain a per-source cache of stream parameters.  The same
 /// `info` also unlocks upstream frame construction (for instance
-/// via [`Mp4DemuxerSource::default_on_packet_as_frame`]).
+/// via [`UriDemuxerSource::default_on_packet_as_frame`]).
 /// Returning `Err(_)` is fatal.
 pub type OnPacketHook = Box<
     dyn FnMut(DemuxedPacket, &VideoInfo, &str, &Router<EncodedMsg>, &HookCtx) -> Result<()>
@@ -184,7 +144,7 @@ pub type OnSourceEosHook =
 
 /// Closure type for `on_error`: classify a GStreamer pipeline
 /// error.  The callback receives the structured
-/// [`Mp4DemuxerError`], the stage's [`Router<EncodedMsg>`] (so
+/// [`UriDemuxerError`], the stage's [`Router<EncodedMsg>`] (so
 /// users can translate errors into downstream control messages
 /// uniformly with the other egress error hooks), and the
 /// [`HookCtx`].
@@ -197,7 +157,7 @@ pub type OnSourceEosHook =
 /// error but keeps the demuxer running, and `Swallow` drops the
 /// error entirely.
 pub type OnErrorHook =
-    Box<dyn FnMut(&Mp4DemuxerError, &Router<EncodedMsg>, &HookCtx) -> ErrorAction + Send + 'static>;
+    Box<dyn FnMut(&UriDemuxerError, &Router<EncodedMsg>, &HookCtx) -> ErrorAction + Send + 'static>;
 
 /// User shutdown hook fired after the demuxer has completed
 /// ([`Source::run`]'s `demuxer.wait()` returned), whether
@@ -210,26 +170,30 @@ pub type OnErrorHook =
 /// implement [`Source`] directly on a bespoke struct.
 pub type OnStoppingHook = Box<dyn FnMut(&SourceContext) + Send + 'static>;
 
-/// A no-inbox [`Source`] that drives a `savant_gstreamer::Mp4Demuxer`
-/// and forwards its output downstream as
+/// A no-inbox [`Source`] that drives a
+/// [`savant_gstreamer::uri_demuxer::UriDemuxer`] and forwards its
+/// output downstream as
 /// [`EncodedMsg`](crate::envelopes::EncodedMsg).
 ///
-/// Construct via [`Mp4DemuxerSource::builder`].
+/// Construct via [`UriDemuxerSource::builder`].
 ///
 /// # Runtime invariant
 ///
 /// All four variant hooks are **always populated** at runtime.  The
 /// builder's `Option<...>` fields are an internal "was the setter
 /// called?" marker;
-/// [`Mp4DemuxerBuilder::build`](Mp4DemuxerBuilder::build) always
-/// substitutes the matching `Mp4DemuxerSource::default_on_*` before
+/// [`UriDemuxerBuilder::build`](UriDemuxerBuilder::build) always
+/// substitutes the matching `UriDemuxerSource::default_on_*` before
 /// constructing the source.  The GStreamer callback therefore never
 /// inspects an `Option` — every demuxed variant is dispatched to a
 /// hook.
-pub struct Mp4DemuxerSource {
-    input: String,
+pub struct UriDemuxerSource {
+    uri: String,
     source_id: String,
     downstream: Option<StageName>,
+    parsed: bool,
+    bin_properties: Vec<(String, PropertyValue)>,
+    source_properties: Vec<(String, PropertyValue)>,
     on_stream_info: OnStreamInfoHook,
     on_packet: OnPacketHook,
     on_source_eos: OnSourceEosHook,
@@ -237,34 +201,16 @@ pub struct Mp4DemuxerSource {
     stopping: OnStoppingHook,
 }
 
-impl Mp4DemuxerSource {
-    /// Start a fluent [`Mp4DemuxerBuilder`] registered under `name`.
-    pub fn builder(name: StageName) -> Mp4DemuxerBuilder {
-        Mp4DemuxerBuilder::new(name)
+impl UriDemuxerSource {
+    /// Start a fluent [`UriDemuxerBuilder`] registered under `name`.
+    pub fn builder(name: StageName) -> UriDemuxerBuilder {
+        UriDemuxerBuilder::new(name)
     }
 
     /// Default `on_stream_info` forwarder.  The returned closure
     /// sends
     /// [`EncodedMsg::StreamInfo { source_id, info }`](crate::envelopes::EncodedMsg::StreamInfo)
     /// via `router.send(...)` — the router's default peer.
-    ///
-    /// Use it as a one-liner when the stream-info sentinel should
-    /// flow unchanged to the downstream stage:
-    ///
-    /// ```ignore
-    /// Mp4DemuxerSource::builder(name)
-    ///     .input(path)
-    ///     .source_id("cam1")
-    ///     .downstream(decoder_name)
-    ///     .on_stream_info(Mp4DemuxerSource::default_on_stream_info())
-    ///     // ...
-    ///     .build()?;
-    /// ```
-    ///
-    /// For name-based routing replace `router.send(msg)` with
-    /// `router.send_to(&peer, msg)` inside a bespoke closure; for
-    /// per-variant metrics wrap this forwarder in a closure that
-    /// bumps counters before (or after) calling it.
     pub fn default_on_stream_info(
     ) -> impl FnMut(VideoInfo, &str, &Router<EncodedMsg>, &HookCtx) -> Result<()> + Send + 'static
     {
@@ -281,22 +227,17 @@ impl Mp4DemuxerSource {
     /// [`EncodedMsg::Packet { source_id, info, packet }`](crate::envelopes::EncodedMsg::Packet)
     /// via `router.send(...)`, stamping every access unit with the
     /// stream-level [`VideoInfo`] observed on the preceding
-    /// [`Mp4DemuxerOutput::StreamInfo`].
+    /// [`UriDemuxerOutput::StreamInfo`].
     ///
     /// Attaching the [`VideoInfo`] in-band lets downstream consumers
     /// (notably the framework's
     /// [`Decoder`](super::decoder::Decoder)) construct
     /// decode frames on the fly without maintaining a per-source
     /// [`VideoInfo`] cache — the message is self-describing.  Use
-    /// [`Mp4DemuxerSource::default_on_packet_as_frame`] instead
+    /// [`UriDemuxerSource::default_on_packet_as_frame`] instead
     /// when you want the demuxer to build the
     /// [`VideoFrameProxy`](savant_core::primitives::frame::VideoFrameProxy)
     /// upstream.
-    ///
-    /// For per-source dispatch across multiple decoders, replace
-    /// `router.send(msg)` with
-    /// `router.send_to(&decoder_for(source_id), msg)` in your own
-    /// closure.
     pub fn default_on_packet(
     ) -> impl FnMut(DemuxedPacket, &VideoInfo, &str, &Router<EncodedMsg>, &HookCtx) -> Result<()>
            + Send
@@ -318,20 +259,8 @@ impl Mp4DemuxerSource {
     /// sends
     /// [`EncodedMsg::Frame { frame, payload: Some(bytes) }`](crate::envelopes::EncodedMsg::Frame).
     ///
-    /// The downstream decoder consumes the variant via its
-    /// [`Handler<FramePayload>`](crate::Handler) path and
-    /// therefore does not need to maintain its own
-    /// [`VideoInfo`]-stash — the frame arrives fully populated
-    /// (codec, dims, fps, pts/dts/duration, keyframe flag all set
-    /// from the demuxer's stream info + packet metadata).
-    ///
-    /// Swap for [`Mp4DemuxerSource::default_on_packet`] when you
-    /// want the decoder to own frame construction instead.  For
-    /// per-variant metrics or source-id-based fanout, wrap this
-    /// forwarder in a custom closure that performs the side effect
-    /// and then constructs / dispatches the frame itself, or
-    /// replace `router.send(msg)` with
-    /// `router.send_to(&peer, msg)`.
+    /// Swap for [`UriDemuxerSource::default_on_packet`] when you
+    /// want the decoder to own frame construction instead.
     pub fn default_on_packet_as_frame(
     ) -> impl FnMut(DemuxedPacket, &VideoInfo, &str, &Router<EncodedMsg>, &HookCtx) -> Result<()>
            + Send
@@ -362,46 +291,35 @@ impl Mp4DemuxerSource {
 
     /// Default `on_error` classifier.  Returns
     /// [`ErrorAction::Fatal`] for every
-    /// [`Mp4DemuxerError`] — matches the legacy "first error latches,
-    /// sink aborts, `Source::run` returns `Err`" behaviour.  Override
-    /// with a custom closure to downgrade specific error variants to
+    /// [`UriDemuxerError`].  Override with a custom closure to
+    /// downgrade specific error variants to
     /// [`ErrorAction::LogAndContinue`] or [`ErrorAction::Swallow`].
-    ///
-    /// The closure takes `&Router<EncodedMsg>` for API parity with
-    /// the other egress error hooks (Decoder / NvInfer / NvTracker)
-    /// but the default ignores it.
     pub fn default_on_error(
-    ) -> impl FnMut(&Mp4DemuxerError, &Router<EncodedMsg>, &HookCtx) -> ErrorAction + Send + 'static
+    ) -> impl FnMut(&UriDemuxerError, &Router<EncodedMsg>, &HookCtx) -> ErrorAction + Send + 'static
     {
         |_err, _router, _ctx| ErrorAction::Fatal
     }
 
-    /// Default user shutdown hook — a no-op.  The template's own
-    /// post-drain cleanup (first-error surfacing, codec check)
-    /// always runs *before* this hook fires, so omitting the
-    /// [`Mp4DemuxerCommonBuilder::stopping`] setter simply means
-    /// "don't add any extra cleanup on top of the built-in
-    /// sequence".
+    /// Default user shutdown hook — a no-op.
     pub fn default_stopping() -> impl FnMut(&SourceContext) + Send + 'static {
         |_ctx| {}
     }
 }
 
 /// Container for the hook closures plus the last-seen
-/// [`VideoInfo`].  The [`Mp4Demuxer`] callback needs `Fn + Send +
+/// [`VideoInfo`].  The [`UriDemuxer`] callback needs `Fn + Send +
 /// Sync + 'static`; our hooks are `FnMut`, so we park them behind a
 /// [`parking_lot::Mutex`] that the callback takes each time it
-/// fires.  Multi-threaded re-entrance is serialised by the mutex —
-/// matching the legacy demux actor's use of an `AtomicBool` +
-/// `Mutex<Option<String>>` for its own internal state.
+/// fires.
 ///
 /// The four variant hooks are non-`Option` by construction — see the
-/// runtime invariant on [`Mp4DemuxerSource`].  `last_stream_info` is
+/// runtime invariant on [`UriDemuxerSource`].  `last_stream_info` is
 /// the one genuinely optional field: it is `None` until the demuxer
-/// emits its first [`Mp4DemuxerOutput::StreamInfo`] and is read by
-/// every subsequent [`Mp4DemuxerOutput::Packet`] so `on_packet` hooks
-/// can see the stream-level metadata without managing it themselves.
-struct Mp4DemuxerHooks {
+/// emits its first [`UriDemuxerOutput::StreamInfo`] and is read by
+/// every subsequent [`UriDemuxerOutput::Packet`] so `on_packet`
+/// hooks can see the stream-level metadata without managing it
+/// themselves.
+struct UriDemuxerHooks {
     on_stream_info: OnStreamInfoHook,
     on_packet: OnPacketHook,
     on_source_eos: OnSourceEosHook,
@@ -409,12 +327,15 @@ struct Mp4DemuxerHooks {
     last_stream_info: Option<VideoInfo>,
 }
 
-impl Source for Mp4DemuxerSource {
+impl Source for UriDemuxerSource {
     fn run(self, ctx: SourceContext) -> Result<()> {
-        let Mp4DemuxerSource {
-            input,
+        let UriDemuxerSource {
+            uri,
             source_id,
             downstream,
+            parsed,
+            bin_properties,
+            source_properties,
             on_stream_info,
             on_packet,
             on_source_eos,
@@ -428,12 +349,12 @@ impl Source for Mp4DemuxerSource {
         let default_sink = router.default_sink();
         let stop_flag = ctx.stop_flag();
 
-        log::info!("[{own_name}] starting source_id={source_id} input={input}");
+        log::info!("[{own_name}] starting source_id={source_id} uri={uri} parsed={parsed}");
 
         // Local latch — first error seen on the pipeline bus is
         // the diagnostically useful one.
         let first_error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
-        let hooks: Arc<Mutex<Mp4DemuxerHooks>> = Arc::new(Mutex::new(Mp4DemuxerHooks {
+        let hooks: Arc<Mutex<UriDemuxerHooks>> = Arc::new(Mutex::new(UriDemuxerHooks {
             on_stream_info,
             on_packet,
             on_source_eos,
@@ -450,13 +371,12 @@ impl Source for Mp4DemuxerSource {
         let own_name_cb = own_name.clone();
         let hook_ctx_cb = hook_ctx.clone();
 
-        let mut demuxer = Mp4Demuxer::new_parsed(&input, move |output| {
-            // Cooperative-stop / already-aborted short-circuit —
-            // matches the legacy `aborted` flag semantics.  Without a
-            // default peer only the stop flag matters.  The
-            // `stop_flag` is shared with [`HookCtx::request_stop`],
-            // so any hook (here or in an upstream stage) can ask the
-            // demuxer to wind down.
+        let mut cfg = UriDemuxerConfig::new(&uri).with_parsed(parsed);
+        cfg.bin_properties = bin_properties;
+        cfg.source_properties = source_properties;
+
+        let mut demuxer = UriDemuxer::new(cfg, move |output| {
+            // Cooperative-stop / already-aborted short-circuit.
             if stop_flag_cb.load(Ordering::Relaxed)
                 || default_sink_cb
                     .as_ref()
@@ -467,7 +387,7 @@ impl Source for Mp4DemuxerSource {
             }
             let mut h = hooks_cb.lock();
             match output {
-                Mp4DemuxerOutput::StreamInfo(info) => {
+                UriDemuxerOutput::StreamInfo(info) => {
                     log::info!(
                         "[{own_name_cb}] stream info: source_id={source_id_cb} {}x{} @ {}/{} codec={:?}",
                         info.width,
@@ -490,7 +410,7 @@ impl Source for Mp4DemuxerSource {
                         }
                     }
                 }
-                Mp4DemuxerOutput::Packet(pkt) => {
+                UriDemuxerOutput::Packet(pkt) => {
                     if let Some(info) = h.last_stream_info {
                         if let Err(e) =
                             (h.on_packet)(pkt, &info, &source_id_cb, &router_cb, &hook_ctx_cb)
@@ -510,7 +430,7 @@ impl Source for Mp4DemuxerSource {
                         }
                     }
                 }
-                Mp4DemuxerOutput::Eos => {
+                UriDemuxerOutput::Eos => {
                     log::info!("[{own_name_cb}] EOS (source_id={source_id_cb})");
                     match (h.on_source_eos)(&source_id_cb, &router_cb, &hook_ctx_cb) {
                         Ok(Flow::Cont) => {}
@@ -534,7 +454,7 @@ impl Source for Mp4DemuxerSource {
                         }
                     }
                 }
-                Mp4DemuxerOutput::Error(e) => {
+                UriDemuxerOutput::Error(e) => {
                     let msg = e.to_string();
                     log::error!("[{own_name_cb}] pipeline error: {msg}");
                     let action = (h.on_error)(&e, &router_cb, &hook_ctx_cb);
@@ -556,16 +476,16 @@ impl Source for Mp4DemuxerSource {
                 }
             }
         })
-        .map_err(|e| anyhow!("Mp4Demuxer::new_parsed: {e}"))?;
+        .map_err(|e| anyhow!("UriDemuxer::new: {e}"))?;
 
         // Poll the demuxer's "finished" condvar with a short
         // timeout so an external stop request (Ctrl+C,
         // cooperative-stop from a hook, or a supervisor broadcast
-        // that flips the shared `stop_flag`) is observed even for
-        // very long files or sources that would otherwise take a
-        // while to drain.  Without this, `wait()` would block on
-        // the condvar until natural EOS and the source thread
-        // would prevent `System::run` from joining on shutdown.
+        // that flips the shared `stop_flag`) is observed even when
+        // the underlying source produces no EOS — e.g. live RTSP /
+        // HTTP streams.  Without this, `wait()` would block on the
+        // condvar indefinitely and the source thread would prevent
+        // `System::run` from joining on shutdown.
         //
         // `POLL_INTERVAL` is short enough (100 ms) to keep Ctrl+C
         // latency negligible while avoiding a busy loop.
@@ -574,14 +494,17 @@ impl Source for Mp4DemuxerSource {
         while !demuxer.wait_timeout(POLL_INTERVAL) {
             if stop_flag.load(Ordering::Relaxed) {
                 log::info!(
-                    "[{own_name}] stop flag set; finishing MP4 demuxer (source_id={source_id})"
+                    "[{own_name}] stop flag set; finishing URI demuxer (source_id={source_id})"
                 );
                 stopped_by_flag = true;
                 break;
             }
         }
         // Tear the GStreamer pipeline down deterministically before
-        // `drop(demuxer)` would otherwise run it implicitly.
+        // `drop(demuxer)` would otherwise run it implicitly — this
+        // keeps the shutdown ordering explicit in the logs and lets
+        // the condvar wake any stragglers so the callback's last
+        // short-circuit returns immediately.
         demuxer.finish();
         let codec = demuxer.detected_codec();
         log::info!(
@@ -591,19 +514,18 @@ impl Source for Mp4DemuxerSource {
         drop(hooks); // release the hook mutex (and its contents) last
 
         // User stopping hook fires AFTER the demuxer has finished
-        // but BEFORE the first-error / codec-check exit path runs
-        // — symmetric with how `Actor::stopping` composes on top of
-        // the template's load-bearing cleanup in other templates.
+        // but BEFORE the first-error / codec-check exit path runs.
         (stopping)(&ctx);
 
         if let Some(err) = first_error.lock().take() {
             bail!("[{own_name}] demux error: {err}");
         }
         // A cooperative stop (Ctrl+C / supervisor broadcast) may
-        // fire before the underlying source ever reported caps;
-        // treat that as a clean exit and only flag the
-        // "empty stream?" case when the demuxer actually finished
-        // under its own steam with no codec ever seen.
+        // fire before the underlying source ever reported caps —
+        // typical for live URIs that are cancelled before the first
+        // STREAM-STARTED.  Treat that as a clean exit; only flag
+        // the "empty stream?" case when the demuxer actually
+        // finished under its own steam with no codec ever seen.
         if codec.is_none() && !stopped_by_flag {
             bail!("[{own_name}] demuxer did not detect a video codec (empty stream?)");
         }
@@ -618,52 +540,49 @@ fn latch_error(slot: &Arc<Mutex<Option<String>>>, msg: String) {
     }
 }
 
-/// Per-variant [`Mp4DemuxerOutput`] hook bundle — one branch per
+/// Per-variant [`UriDemuxerOutput`] hook bundle — one branch per
 /// demuxed variant plus the error classifier.
 ///
-/// Built through [`Mp4DemuxerResults::builder`] and handed to
-/// [`Mp4DemuxerBuilder::results`].  Omitted branches auto-install
-/// the matching `Mp4DemuxerSource::default_on_*` at build time, so
-/// the runtime invariant "every [`Mp4DemuxerOutput`] variant is
-/// always dispatched to a user-supplied or auto-installed hook"
-/// holds regardless of how much the user overrides.
-pub struct Mp4DemuxerResults {
+/// Built through [`UriDemuxerResults::builder`] and handed to
+/// [`UriDemuxerBuilder::results`].  Omitted branches auto-install
+/// the matching `UriDemuxerSource::default_on_*` at build time.
+pub struct UriDemuxerResults {
     on_stream_info: OnStreamInfoHook,
     on_packet: OnPacketHook,
     on_source_eos: OnSourceEosHook,
     on_error: OnErrorHook,
 }
 
-impl Mp4DemuxerResults {
+impl UriDemuxerResults {
     /// Start a builder that auto-installs every default on
-    /// [`Mp4DemuxerResultsBuilder::build`].
-    pub fn builder() -> Mp4DemuxerResultsBuilder {
-        Mp4DemuxerResultsBuilder::new()
+    /// [`UriDemuxerResultsBuilder::build`].
+    pub fn builder() -> UriDemuxerResultsBuilder {
+        UriDemuxerResultsBuilder::new()
     }
 }
 
-impl Default for Mp4DemuxerResults {
+impl Default for UriDemuxerResults {
     /// Every branch wired to its matching
-    /// `Mp4DemuxerSource::default_on_*`.  `on_packet` defaults to
-    /// [`Mp4DemuxerSource::default_on_packet_as_frame`] — upstream
+    /// `UriDemuxerSource::default_on_*`.  `on_packet` defaults to
+    /// [`UriDemuxerSource::default_on_packet_as_frame`] — upstream
     /// frame construction, matching today's "no setter called"
-    /// behaviour.
+    /// behaviour of the mp4 variant.
     fn default() -> Self {
-        Mp4DemuxerResultsBuilder::new().build()
+        UriDemuxerResultsBuilder::new().build()
     }
 }
 
-/// Fluent builder for [`Mp4DemuxerResults`].
-pub struct Mp4DemuxerResultsBuilder {
+/// Fluent builder for [`UriDemuxerResults`].
+pub struct UriDemuxerResultsBuilder {
     on_stream_info: Option<OnStreamInfoHook>,
     on_packet: Option<OnPacketHook>,
     on_source_eos: Option<OnSourceEosHook>,
     on_error: Option<OnErrorHook>,
 }
 
-impl Mp4DemuxerResultsBuilder {
+impl UriDemuxerResultsBuilder {
     /// Empty bundle — every hook defaults to its matching
-    /// `Mp4DemuxerSource::default_*` equivalent at
+    /// `UriDemuxerSource::default_*` equivalent at
     /// [`build`](Self::build) time.
     pub fn new() -> Self {
         Self {
@@ -674,9 +593,7 @@ impl Mp4DemuxerResultsBuilder {
         }
     }
 
-    /// Override the `on_stream_info` hook.  Omitting this setter is
-    /// equivalent to calling
-    /// `.on_stream_info(Mp4DemuxerSource::default_on_stream_info())`.
+    /// Override the `on_stream_info` hook.
     pub fn on_stream_info<F>(mut self, f: F) -> Self
     where
         F: FnMut(VideoInfo, &str, &Router<EncodedMsg>, &HookCtx) -> Result<()> + Send + 'static,
@@ -687,13 +604,7 @@ impl Mp4DemuxerResultsBuilder {
 
     /// Override the `on_packet` hook.  Omitting this setter is
     /// equivalent to calling
-    /// `.on_packet(Mp4DemuxerSource::default_on_packet_as_frame())`
-    /// — the demuxer constructs a
-    /// [`VideoFrameProxy`](savant_core::primitives::frame::VideoFrameProxy)
-    /// upstream and sends
-    /// [`EncodedMsg::Frame`](crate::envelopes::EncodedMsg::Frame).
-    /// Swap to [`Mp4DemuxerSource::default_on_packet`] for
-    /// downstream frame construction.
+    /// `.on_packet(UriDemuxerSource::default_on_packet_as_frame())`.
     pub fn on_packet<F>(mut self, f: F) -> Self
     where
         F: FnMut(DemuxedPacket, &VideoInfo, &str, &Router<EncodedMsg>, &HookCtx) -> Result<()>
@@ -704,13 +615,7 @@ impl Mp4DemuxerResultsBuilder {
         self
     }
 
-    /// Override the `on_source_eos` hook.  Omitting this setter is
-    /// equivalent to calling
-    /// `.on_source_eos(Mp4DemuxerSource::default_on_source_eos())`
-    /// — forward `EncodedMsg::SourceEos` downstream and return
-    /// `Ok(Flow::Cont)`.  Return `Ok(Flow::Stop)` to request
-    /// cooperative shutdown of the source; `Err(_)` is logged,
-    /// latched, and also requests shutdown.
+    /// Override the `on_source_eos` hook.
     pub fn on_source_eos<F>(mut self, f: F) -> Self
     where
         F: FnMut(&str, &Router<EncodedMsg>, &HookCtx) -> Result<Flow> + Send + 'static,
@@ -719,16 +624,10 @@ impl Mp4DemuxerResultsBuilder {
         self
     }
 
-    /// Override the `on_error` classifier.  Omitting this setter is
-    /// equivalent to calling
-    /// `.on_error(Mp4DemuxerSource::default_on_error())` — classify
-    /// every error as [`ErrorAction::Fatal`], matching the legacy
-    /// mp4_demux behaviour.  The closure receives the router for
-    /// API parity with other egress error hooks; it is free to
-    /// ignore the router.
+    /// Override the `on_error` classifier.
     pub fn on_error<F>(mut self, f: F) -> Self
     where
-        F: FnMut(&Mp4DemuxerError, &Router<EncodedMsg>, &HookCtx) -> ErrorAction + Send + 'static,
+        F: FnMut(&UriDemuxerError, &Router<EncodedMsg>, &HookCtx) -> ErrorAction + Send + 'static,
     {
         self.on_error = Some(Box::new(f));
         self
@@ -736,74 +635,64 @@ impl Mp4DemuxerResultsBuilder {
 
     /// Finalise the bundle, substituting defaults for every omitted
     /// branch.
-    pub fn build(self) -> Mp4DemuxerResults {
-        let Mp4DemuxerResultsBuilder {
+    pub fn build(self) -> UriDemuxerResults {
+        let UriDemuxerResultsBuilder {
             on_stream_info,
             on_packet,
             on_source_eos,
             on_error,
         } = self;
-        Mp4DemuxerResults {
+        UriDemuxerResults {
             on_stream_info: on_stream_info
-                .unwrap_or_else(|| Box::new(Mp4DemuxerSource::default_on_stream_info())),
+                .unwrap_or_else(|| Box::new(UriDemuxerSource::default_on_stream_info())),
             on_packet: on_packet
-                .unwrap_or_else(|| Box::new(Mp4DemuxerSource::default_on_packet_as_frame())),
+                .unwrap_or_else(|| Box::new(UriDemuxerSource::default_on_packet_as_frame())),
             on_source_eos: on_source_eos
-                .unwrap_or_else(|| Box::new(Mp4DemuxerSource::default_on_source_eos())),
-            on_error: on_error.unwrap_or_else(|| Box::new(Mp4DemuxerSource::default_on_error())),
+                .unwrap_or_else(|| Box::new(UriDemuxerSource::default_on_source_eos())),
+            on_error: on_error.unwrap_or_else(|| Box::new(UriDemuxerSource::default_on_error())),
         }
     }
 }
 
-impl Default for Mp4DemuxerResultsBuilder {
+impl Default for UriDemuxerResultsBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
 /// Loop-level common knobs + user shutdown hook for
-/// [`Mp4DemuxerSource`].  Built through
-/// [`Mp4DemuxerCommon::builder`] and handed to
-/// [`Mp4DemuxerBuilder::common`].
-pub struct Mp4DemuxerCommon {
+/// [`UriDemuxerSource`].  Built through
+/// [`UriDemuxerCommon::builder`] and handed to
+/// [`UriDemuxerBuilder::common`].
+pub struct UriDemuxerCommon {
     stopping: OnStoppingHook,
 }
 
-impl Mp4DemuxerCommon {
+impl UriDemuxerCommon {
     /// Start a builder seeded with the no-op stopping hook.
-    pub fn builder() -> Mp4DemuxerCommonBuilder {
-        Mp4DemuxerCommonBuilder::new()
+    pub fn builder() -> UriDemuxerCommonBuilder {
+        UriDemuxerCommonBuilder::new()
     }
 }
 
-impl Default for Mp4DemuxerCommon {
-    /// No-op `stopping` — matches today's "no hook" behaviour.
+impl Default for UriDemuxerCommon {
     fn default() -> Self {
-        Mp4DemuxerCommonBuilder::new().build()
+        UriDemuxerCommonBuilder::new().build()
     }
 }
 
-/// Fluent builder for [`Mp4DemuxerCommon`].
-pub struct Mp4DemuxerCommonBuilder {
+/// Fluent builder for [`UriDemuxerCommon`].
+pub struct UriDemuxerCommonBuilder {
     stopping: Option<OnStoppingHook>,
 }
 
-impl Mp4DemuxerCommonBuilder {
+impl UriDemuxerCommonBuilder {
     /// Empty bundle — `stopping` defaults to a no-op.
     pub fn new() -> Self {
         Self { stopping: None }
     }
 
-    /// Override the user shutdown hook — fired once the demuxer
-    /// has finished (`demuxer.wait()` returned), **before** the
-    /// first-error / codec-check exit path runs.  Runs on the
-    /// source thread with access to the [`SourceContext`].  Use
-    /// for final metrics flushes, bespoke log lines, or custom
-    /// bookkeeping that must observe the demuxer's post-drain
-    /// state.  The template's own cleanup (demuxer drop,
-    /// first-error surfacing) is **load-bearing** and always runs
-    /// after this hook; users who need to replace that entirely
-    /// should implement [`Source`] directly on a bespoke struct.
+    /// Override the user shutdown hook.
     pub fn stopping<F>(mut self, f: F) -> Self
     where
         F: FnMut(&SourceContext) + Send + 'static,
@@ -812,59 +701,62 @@ impl Mp4DemuxerCommonBuilder {
         self
     }
 
-    /// Finalise the bundle, substituting the no-op default for an
-    /// omitted `stopping` setter.
-    pub fn build(self) -> Mp4DemuxerCommon {
-        let Mp4DemuxerCommonBuilder { stopping } = self;
-        Mp4DemuxerCommon {
-            stopping: stopping.unwrap_or_else(|| Box::new(Mp4DemuxerSource::default_stopping())),
+    /// Finalise the bundle.
+    pub fn build(self) -> UriDemuxerCommon {
+        let UriDemuxerCommonBuilder { stopping } = self;
+        UriDemuxerCommon {
+            stopping: stopping.unwrap_or_else(|| Box::new(UriDemuxerSource::default_stopping())),
         }
     }
 }
 
-impl Default for Mp4DemuxerCommonBuilder {
+impl Default for UriDemuxerCommonBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-/// Fluent builder for [`Mp4DemuxerSource`].
+/// Fluent builder for [`UriDemuxerSource`].
 ///
-/// The builder only exposes wiring-level configuration at the top
-/// level (`input`, `source_id`, `downstream`).  Per-variant
-/// demuxer-output hooks live on [`Mp4DemuxerResults`]; the user
-/// shutdown hook lives on [`Mp4DemuxerCommon`].  Install them via
-/// [`Mp4DemuxerBuilder::results`] and [`Mp4DemuxerBuilder::common`].
-pub struct Mp4DemuxerBuilder {
+/// The builder exposes wiring-level configuration at the top level
+/// (`input`, `source_id`, `downstream`, `parsed`, `bin_properties`,
+/// `source_properties`).  Per-variant demuxer-output hooks live on
+/// [`UriDemuxerResults`]; the user shutdown hook lives on
+/// [`UriDemuxerCommon`].
+pub struct UriDemuxerBuilder {
     name: StageName,
     input: Option<String>,
     source_id: Option<String>,
     downstream: Option<StageName>,
-    results: Option<Mp4DemuxerResults>,
-    common: Option<Mp4DemuxerCommon>,
+    parsed: bool,
+    bin_properties: Vec<(String, PropertyValue)>,
+    source_properties: Vec<(String, PropertyValue)>,
+    results: Option<UriDemuxerResults>,
+    common: Option<UriDemuxerCommon>,
 }
 
-impl Mp4DemuxerBuilder {
-    /// Start a builder for a demux source registered under `name`.
-    ///
-    /// Every per-variant hook defaults to its
-    /// `Mp4DemuxerSource::default_on_*` equivalent; the user
-    /// shutdown hook defaults to a no-op.  The user only needs to
-    /// supply `input` and `source_id`; `downstream` / `results` /
-    /// `common` are optional and composable.
+impl UriDemuxerBuilder {
+    /// Start a builder for a URI demux source registered under
+    /// `name`.  `parsed` defaults to `true` (matches
+    /// [`UriDemuxerConfig::new`]); bin/source property vectors
+    /// default to empty.
     pub fn new(name: StageName) -> Self {
         Self {
             name,
             input: None,
             source_id: None,
             downstream: None,
+            parsed: true,
+            bin_properties: Vec::new(),
+            source_properties: Vec::new(),
             results: None,
             common: None,
         }
     }
 
-    /// Required: file path or URI passed to
-    /// [`Mp4Demuxer::new_parsed`].
+    /// Required: URI passed to
+    /// [`UriDemuxerConfig::new`] (e.g. `file:///path.mp4`,
+    /// `http://…/a.m3u8`, `rtsp://cam/stream`).
     pub fn input(mut self, input: impl Into<String>) -> Self {
         self.input = Some(input.into());
         self
@@ -881,63 +773,88 @@ impl Mp4DemuxerBuilder {
     }
 
     /// Optional default peer installed on the
-    /// [`Router<EncodedMsg>`] handed to every variant hook.  Hooks
-    /// call `router.send(msg)` to route to this peer and
-    /// `router.send_to(&peer, msg)` to address any other registered
-    /// actor by name.
+    /// [`Router<EncodedMsg>`] handed to every variant hook.
     pub fn downstream(mut self, peer: StageName) -> Self {
         self.downstream = Some(peer);
         self
     }
 
-    /// Install a [`Mp4DemuxerResults`] bundle — one branch per
-    /// demuxed variant.  Omitting this call is equivalent to
-    /// `.results(Mp4DemuxerResults::default())`, which wires every
-    /// branch to its matching `Mp4DemuxerSource::default_on_*`.
-    pub fn results(mut self, r: Mp4DemuxerResults) -> Self {
+    /// Whether to request a parsed (Annex-B / AU-aligned) elementary
+    /// stream from the underlying
+    /// [`savant_gstreamer::uri_demuxer::UriDemuxer`].  Forwarded to
+    /// [`UriDemuxerConfig::with_parsed`].  Defaults to `true`.
+    pub fn parsed(mut self, parsed: bool) -> Self {
+        self.parsed = parsed;
+        self
+    }
+
+    /// Properties applied to the top-level `urisourcebin`
+    /// (e.g. `buffer-size`, `use-buffering`, `connection-speed`).
+    /// Replaces any previously-accumulated bin-property set.
+    pub fn bin_properties(mut self, props: Vec<(String, PropertyValue)>) -> Self {
+        self.bin_properties = props;
+        self
+    }
+
+    /// Properties applied to the dynamically-created inner source
+    /// element via the `source-setup` signal
+    /// (e.g. `rtspsrc.latency`, `souphttpsrc.user-agent`).  Replaces
+    /// any previously-accumulated source-property set.
+    pub fn source_properties(mut self, props: Vec<(String, PropertyValue)>) -> Self {
+        self.source_properties = props;
+        self
+    }
+
+    /// Install a [`UriDemuxerResults`] bundle — one branch per
+    /// demuxed variant.
+    pub fn results(mut self, r: UriDemuxerResults) -> Self {
         self.results = Some(r);
         self
     }
 
-    /// Install a [`Mp4DemuxerCommon`] bundle — currently just the
-    /// `stopping` hook.  Omitting this call is equivalent to
-    /// `.common(Mp4DemuxerCommon::default())`.
-    pub fn common(mut self, c: Mp4DemuxerCommon) -> Self {
+    /// Install a [`UriDemuxerCommon`] bundle.
+    pub fn common(mut self, c: UriDemuxerCommon) -> Self {
         self.common = Some(c);
         self
     }
 
     /// Finalise the builder and obtain the Layer-A
-    /// [`SourceBuilder<Mp4DemuxerSource>`] ready for
+    /// [`SourceBuilder<UriDemuxerSource>`] ready for
     /// [`System::register_source`](super::super::System::register_source).
     ///
     /// # Errors
     ///
     /// Returns `Err` if `input` or `source_id` is missing.
     /// `downstream` is optional — omit it for a drain-only source.
-    pub fn build(self) -> Result<SourceBuilder<Mp4DemuxerSource>> {
-        let Mp4DemuxerBuilder {
+    pub fn build(self) -> Result<SourceBuilder<UriDemuxerSource>> {
+        let UriDemuxerBuilder {
             name,
             input,
             source_id,
             downstream,
+            parsed,
+            bin_properties,
+            source_properties,
             results,
             common,
         } = self;
-        let input = input.ok_or_else(|| anyhow!("Mp4DemuxerSource: missing input"))?;
-        let source_id = source_id.ok_or_else(|| anyhow!("Mp4DemuxerSource: missing source_id"))?;
-        let Mp4DemuxerResults {
+        let input = input.ok_or_else(|| anyhow!("UriDemuxerSource: missing input"))?;
+        let source_id = source_id.ok_or_else(|| anyhow!("UriDemuxerSource: missing source_id"))?;
+        let UriDemuxerResults {
             on_stream_info,
             on_packet,
             on_source_eos,
             on_error,
         } = results.unwrap_or_default();
-        let Mp4DemuxerCommon { stopping } = common.unwrap_or_default();
+        let UriDemuxerCommon { stopping } = common.unwrap_or_default();
         Ok(SourceBuilder::new(name).factory(move |_bx| {
-            Ok(Mp4DemuxerSource {
-                input,
+            Ok(UriDemuxerSource {
+                uri: input,
                 source_id,
                 downstream,
+                parsed,
+                bin_properties,
+                source_properties,
                 on_stream_info,
                 on_packet,
                 on_source_eos,
@@ -953,7 +870,7 @@ mod tests {
     use super::*;
     use crate::supervisor::{StageKind, StageName};
 
-    fn err_msg(result: Result<SourceBuilder<Mp4DemuxerSource>>) -> String {
+    fn err_msg(result: Result<SourceBuilder<UriDemuxerSource>>) -> String {
         match result {
             Err(e) => e.to_string(),
             Ok(_) => panic!("expected error"),
@@ -962,24 +879,23 @@ mod tests {
 
     #[test]
     fn builder_requires_input_and_source_id() {
-        let name = StageName::unnamed(StageKind::Mp4Demux);
-        assert!(err_msg(Mp4DemuxerSource::builder(name.clone()).build()).contains("missing input"));
+        let name = StageName::unnamed(StageKind::UriDemux);
+        assert!(err_msg(UriDemuxerSource::builder(name.clone()).build()).contains("missing input"));
         assert!(err_msg(
-            Mp4DemuxerSource::builder(name.clone())
-                .input("/tmp/x.mp4")
+            UriDemuxerSource::builder(name.clone())
+                .input("file:///tmp/x.mp4")
                 .build()
         )
         .contains("missing source_id"));
     }
 
-    /// `downstream` is optional now — a drain-only source (no
-    /// default peer) still builds.  The resulting source silently
-    /// drops all packets through the default `router.send(...)` path.
+    /// `downstream` is optional — a drain-only source (no default
+    /// peer) still builds.
     #[test]
     fn builder_without_downstream_is_accepted() {
-        let name = StageName::unnamed(StageKind::Mp4Demux);
-        let _ = Mp4DemuxerSource::builder(name)
-            .input("/tmp/x.mp4")
+        let name = StageName::unnamed(StageKind::UriDemux);
+        let _ = UriDemuxerSource::builder(name)
+            .input("file:///tmp/x.mp4")
             .source_id("s")
             .build()
             .expect("no-downstream builder is accepted");
@@ -987,13 +903,16 @@ mod tests {
 
     #[test]
     fn builder_accepts_all_hooks() {
-        let name = StageName::unnamed(StageKind::Mp4Demux);
-        let sb = Mp4DemuxerSource::builder(name)
-            .input("/tmp/x.mp4")
+        let name = StageName::unnamed(StageKind::UriDemux);
+        let sb = UriDemuxerSource::builder(name)
+            .input("file:///tmp/x.mp4")
             .source_id("cam1")
             .downstream(StageName::unnamed(StageKind::Decoder))
+            .parsed(true)
+            .bin_properties(vec![("buffer-size".into(), PropertyValue::I64(8192))])
+            .source_properties(vec![("latency".into(), PropertyValue::U64(200))])
             .results(
-                Mp4DemuxerResults::builder()
+                UriDemuxerResults::builder()
                     .on_stream_info(|info, sid, router, _ctx| {
                         router.send(EncodedMsg::StreamInfo {
                             source_id: sid.to_string(),
@@ -1016,7 +935,7 @@ mod tests {
                         Ok(Flow::Cont)
                     })
                     .on_error(
-                        |_err: &Mp4DemuxerError, _router: &Router<EncodedMsg>, _ctx: &HookCtx| {
+                        |_err: &UriDemuxerError, _router: &Router<EncodedMsg>, _ctx: &HookCtx| {
                             ErrorAction::Fatal
                         },
                     )
@@ -1024,8 +943,6 @@ mod tests {
             )
             .build()
             .unwrap();
-        // No way to run without a real file; this is a compile-shape
-        // test.  The SourceBuilder carries our factory.
         let _ = sb;
     }
 
@@ -1034,17 +951,17 @@ mod tests {
     /// generic hook bounds as-is.
     #[test]
     fn builder_accepts_default_forwarders() {
-        let name = StageName::unnamed(StageKind::Mp4Demux);
-        let sb = Mp4DemuxerSource::builder(name)
-            .input("/tmp/x.mp4")
+        let name = StageName::unnamed(StageKind::UriDemux);
+        let sb = UriDemuxerSource::builder(name)
+            .input("file:///tmp/x.mp4")
             .source_id("cam1")
             .downstream(StageName::unnamed(StageKind::Decoder))
             .results(
-                Mp4DemuxerResults::builder()
-                    .on_stream_info(Mp4DemuxerSource::default_on_stream_info())
-                    .on_packet(Mp4DemuxerSource::default_on_packet())
-                    .on_source_eos(Mp4DemuxerSource::default_on_source_eos())
-                    .on_error(Mp4DemuxerSource::default_on_error())
+                UriDemuxerResults::builder()
+                    .on_stream_info(UriDemuxerSource::default_on_stream_info())
+                    .on_packet(UriDemuxerSource::default_on_packet())
+                    .on_source_eos(UriDemuxerSource::default_on_source_eos())
+                    .on_error(UriDemuxerSource::default_on_error())
                     .build(),
             )
             .build()
@@ -1056,17 +973,17 @@ mod tests {
     /// builder in place of `default_on_packet`.
     #[test]
     fn builder_accepts_default_on_packet_as_frame() {
-        let name = StageName::unnamed(StageKind::Mp4Demux);
-        let sb = Mp4DemuxerSource::builder(name)
-            .input("/tmp/x.mp4")
+        let name = StageName::unnamed(StageKind::UriDemux);
+        let sb = UriDemuxerSource::builder(name)
+            .input("file:///tmp/x.mp4")
             .source_id("cam1")
             .downstream(StageName::unnamed(StageKind::Decoder))
             .results(
-                Mp4DemuxerResults::builder()
-                    .on_stream_info(Mp4DemuxerSource::default_on_stream_info())
-                    .on_packet(Mp4DemuxerSource::default_on_packet_as_frame())
-                    .on_source_eos(Mp4DemuxerSource::default_on_source_eos())
-                    .on_error(Mp4DemuxerSource::default_on_error())
+                UriDemuxerResults::builder()
+                    .on_stream_info(UriDemuxerSource::default_on_stream_info())
+                    .on_packet(UriDemuxerSource::default_on_packet_as_frame())
+                    .on_source_eos(UriDemuxerSource::default_on_source_eos())
+                    .on_error(UriDemuxerSource::default_on_error())
                     .build(),
             )
             .build()
@@ -1074,20 +991,20 @@ mod tests {
         let _ = sb;
     }
 
-    /// The [`Mp4DemuxerCommon`] bundle accepts a user-supplied
+    /// The [`UriDemuxerCommon`] bundle accepts a user-supplied
     /// `.stopping(F)` closure.
     #[test]
     fn builder_accepts_user_stopping() {
         use std::sync::atomic::{AtomicBool, Ordering};
         let flag = Arc::new(AtomicBool::new(false));
         let flag_hook = flag.clone();
-        let name = StageName::unnamed(StageKind::Mp4Demux);
-        let _ = Mp4DemuxerSource::builder(name)
-            .input("/tmp/x.mp4")
+        let name = StageName::unnamed(StageKind::UriDemux);
+        let _ = UriDemuxerSource::builder(name)
+            .input("file:///tmp/x.mp4")
             .source_id("cam1")
             .downstream(StageName::unnamed(StageKind::Decoder))
             .common(
-                Mp4DemuxerCommon::builder()
+                UriDemuxerCommon::builder()
                     .stopping(move |_ctx| {
                         flag_hook.store(true, Ordering::SeqCst);
                     })
@@ -1101,28 +1018,21 @@ mod tests {
     /// Runtime invariant: `build()` succeeds with only the three
     /// mandatory setters (`input`, `source_id`, `downstream`) and
     /// auto-installs all four `default_on_*` forwarders plus the
-    /// no-op stopping hook.  The `SourceFactory` resolves and
-    /// produces a `Mp4DemuxerSource` whose hook fields are
-    /// non-`Option` by construction — proving that no variant is
-    /// ever dispatched to `None` at runtime.
+    /// no-op stopping hook, defaulting `parsed = true` and empty
+    /// property vectors.
     #[test]
     fn builder_accepts_bare_minimum() {
         use crate::context::BuildCtx;
         use crate::registry::Registry;
         use crate::shared::SharedStore;
 
-        let name = StageName::unnamed(StageKind::Mp4Demux);
-        let sb = Mp4DemuxerSource::builder(name.clone())
-            .input("/tmp/x.mp4")
+        let name = StageName::unnamed(StageKind::UriDemux);
+        let sb = UriDemuxerSource::builder(name.clone())
+            .input("file:///tmp/x.mp4")
             .source_id("cam1")
             .downstream(StageName::unnamed(StageKind::Decoder))
             .build()
             .expect("bare-minimum builder is accepted");
-        // Tear the SourceBuilder apart and actually run the factory
-        // so the defaults installed in `build()` materialise into the
-        // runtime source struct.  This catches any future regression
-        // where a setter override path accidentally bypasses the
-        // `unwrap_or_else(default_*)` chain.
         let parts = sb.into_parts();
         assert_eq!(parts.name, name);
         let reg = Arc::new(Registry::new());
@@ -1130,19 +1040,22 @@ mod tests {
         let stop_flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let bx = BuildCtx::new(&parts.name, &reg, &shared, &stop_flag);
         let src = (parts.factory)(&bx).expect("factory resolves");
-        // Pattern-match proves every hook is non-`Option`; the
-        // compiler would refuse if any field were wrapped in
-        // `Option<_>`.  We also bind each hook to a variable to
-        // silence the unused-fields lint and document intent.
-        let Mp4DemuxerSource {
-            input: _,
+        // Pattern-match proves every hook is non-`Option`.
+        let UriDemuxerSource {
+            uri: _,
             source_id: _,
             downstream: _,
+            parsed,
+            bin_properties,
+            source_properties,
             on_stream_info: _,
             on_packet: _,
             on_source_eos: _,
             on_error: _,
             stopping: _,
         } = src;
+        assert!(parsed, "parsed defaults to true");
+        assert!(bin_properties.is_empty());
+        assert!(source_properties.is_empty());
     }
 }

--- a/savant_python/pytests/test_uri_demuxer.py
+++ b/savant_python/pytests/test_uri_demuxer.py
@@ -1,0 +1,488 @@
+"""Tests for savant_rs.gstreamer.UriDemuxer (requires gst feature).
+
+Parallel to test_mp4_demuxer.py. All tests build a local temp MP4 via
+Mp4Muxer and consume it via ``file://`` URI, which is the lowest-friction
+URI scheme that is guaranteed to work in any GStreamer build.
+
+The last test class (``TestMp4DemuxerParity``) cross-checks the ground
+truth: Mp4Demuxer and UriDemuxer consuming the same file must yield the
+same VideoInfo, packet count, per-packet PTS / keyframe flag, and the
+same normalized H.264 slice payload bytes.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import threading
+from pathlib import Path
+from typing import List
+
+import pytest
+
+try:
+    from savant_rs.gstreamer import (
+        Codec,
+        DemuxedPacket,
+        Mp4Demuxer,
+        Mp4DemuxerOutput,
+        Mp4Muxer,
+        UriDemuxer,
+        VideoInfo,
+    )
+except ImportError:
+    Codec = None
+    DemuxedPacket = None
+    Mp4Demuxer = None
+    Mp4DemuxerOutput = None
+    Mp4Muxer = None
+    UriDemuxer = None
+    VideoInfo = None
+
+
+def _gst_runtime_available() -> bool:
+    if Mp4Muxer is None or UriDemuxer is None:
+        return False
+    path = ""
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as f:
+            path = f.name
+        muxer = Mp4Muxer(Codec.H264, path)
+        muxer.finish()
+        return True
+    except RuntimeError:
+        return False
+    finally:
+        if path:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+
+
+_HAS_GST_RUNTIME = _gst_runtime_available()
+
+requires_gst_runtime = pytest.mark.skipif(
+    not _HAS_GST_RUNTIME,
+    reason="GStreamer runtime not available (missing plugins or misconfigured)",
+)
+
+H264_SPS_PPS_IDR: bytes = bytes(
+    [
+        # SPS
+        0x00, 0x00, 0x00, 0x01, 0x67, 0x42, 0x00, 0x0A,
+        0xE9, 0x40, 0x40, 0x04, 0x00, 0x00, 0x00, 0x02,
+        # PPS
+        0x00, 0x00, 0x00, 0x01, 0x68, 0xCE, 0x38, 0x80,
+        # IDR slice (minimal)
+        0x00, 0x00, 0x00, 0x01, 0x65, 0x88, 0x80, 0x40,
+    ]
+)
+
+
+def _make_h264_mp4(path: str, num_frames: int = 5) -> None:
+    muxer = Mp4Muxer(Codec.H264, path, fps_num=30, fps_den=1)
+    dur = 33_333_333
+    for i in range(num_frames):
+        muxer.push(H264_SPS_PPS_IDR, pts_ns=i * dur, duration_ns=dur)
+    muxer.finish()
+
+
+def _file_uri(path: str) -> str:
+    return Path(path).resolve().as_uri()
+
+
+class PacketCollector:
+    """Thread-safe collector for UriDemuxer callback outputs."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.packets: List[DemuxedPacket] = []
+        self.eos_count: int = 0
+        self.errors: List[str] = []
+        self.stream_infos: List[VideoInfo] = []
+
+    def __call__(self, output: Mp4DemuxerOutput) -> None:
+        with self._lock:
+            if output.is_packet:
+                self.packets.append(output.as_packet())
+            elif output.is_eos:
+                self.eos_count += 1
+            elif output.is_error:
+                self.errors.append(output.as_error_message())
+            elif output.is_stream_info:
+                self.stream_infos.append(output.as_stream_info())
+
+
+# ── Construction ─────────────────────────────────────────────────────────
+
+
+@requires_gst_runtime
+class TestConstruction:
+    def test_empty_uri_raises(self):
+        with pytest.raises(RuntimeError):
+            UriDemuxer("", lambda _o: None)
+
+    def test_malformed_uri_raises(self):
+        with pytest.raises(RuntimeError):
+            UriDemuxer("not-a-uri", lambda _o: None)
+
+    def test_create_from_file_uri(self):
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as f:
+            path = f.name
+        try:
+            _make_h264_mp4(path)
+            demuxer = UriDemuxer(_file_uri(path), PacketCollector())
+            assert not demuxer.is_finished
+            demuxer.finish()
+            assert demuxer.is_finished
+        finally:
+            os.unlink(path)
+
+
+# ── Callback delivery ───────────────────────────────────────────────────
+
+
+@requires_gst_runtime
+class TestCallbackDelivery:
+    def test_packets_delivered_via_callback(self):
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as f:
+            path = f.name
+        try:
+            _make_h264_mp4(path, 5)
+            collector = PacketCollector()
+            demuxer = UriDemuxer(_file_uri(path), collector)
+            demuxer.wait()
+            assert len(collector.packets) > 0
+            assert collector.eos_count >= 1
+            assert len(collector.errors) == 0
+        finally:
+            os.unlink(path)
+
+    def test_wait_timeout_returns_true_on_completion(self):
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as f:
+            path = f.name
+        try:
+            _make_h264_mp4(path, 3)
+            collector = PacketCollector()
+            demuxer = UriDemuxer(_file_uri(path), collector)
+            assert demuxer.wait_timeout(10_000) is True
+            assert len(collector.packets) > 0
+        finally:
+            os.unlink(path)
+
+    def test_stream_info_fires_once_before_first_packet(self):
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as f:
+            path = f.name
+        try:
+            _make_h264_mp4(path, 4)
+            outputs: list = []
+            demuxer = UriDemuxer(_file_uri(path), lambda o: outputs.append(o))
+            demuxer.wait()
+
+            stream_info_indices = [i for i, o in enumerate(outputs) if o.is_stream_info]
+            packet_indices = [i for i, o in enumerate(outputs) if o.is_packet]
+            meaningful = [
+                i for i, o in enumerate(outputs) if o.is_stream_info or o.is_packet
+            ]
+            assert len(stream_info_indices) == 1
+            assert len(packet_indices) > 0
+            assert stream_info_indices[0] == min(meaningful)
+        finally:
+            os.unlink(path)
+
+
+# ── Properties: bin_properties ──────────────────────────────────────────
+
+
+@requires_gst_runtime
+class TestBinProperties:
+    def test_known_bin_property_accepted(self):
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as f:
+            path = f.name
+        try:
+            _make_h264_mp4(path, 3)
+            collector = PacketCollector()
+            # urisourcebin has a "buffer-size" property (guint).
+            demuxer = UriDemuxer(
+                _file_uri(path),
+                collector,
+                bin_properties={"buffer-size": 8_388_608},
+            )
+            assert demuxer.wait_timeout(10_000) is True
+            assert len(collector.packets) > 0
+            assert len(collector.errors) == 0
+        finally:
+            os.unlink(path)
+
+    def test_unknown_bin_property_raises(self):
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as f:
+            path = f.name
+        try:
+            _make_h264_mp4(path, 1)
+            with pytest.raises(RuntimeError):
+                UriDemuxer(
+                    _file_uri(path),
+                    lambda _o: None,
+                    bin_properties={"no-such-property-xyz": 1},
+                )
+        finally:
+            os.unlink(path)
+
+    def test_invalid_property_value_type_raises_type_error(self):
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as f:
+            path = f.name
+        try:
+            _make_h264_mp4(path, 1)
+            with pytest.raises(TypeError):
+                UriDemuxer(
+                    _file_uri(path),
+                    lambda _o: None,
+                    bin_properties={"buffer-size": [1, 2, 3]},  # list is unsupported
+                )
+        finally:
+            os.unlink(path)
+
+
+# ── Properties: source_properties (via source-setup signal) ────────────
+
+
+@requires_gst_runtime
+class TestSourceProperties:
+    def test_unknown_source_property_surfaces_error_to_callback(self):
+        """An unknown source-element property must NOT abort construction;
+        it surfaces as an error output to the callback (so pipeline-wide
+        side-effects stay contained)."""
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as f:
+            path = f.name
+        try:
+            _make_h264_mp4(path, 2)
+            collector = PacketCollector()
+            demuxer = UriDemuxer(
+                _file_uri(path),
+                collector,
+                source_properties={"definitely-not-a-property-foo": 42},
+            )
+            demuxer.wait_timeout(5_000)
+            assert any(
+                "definitely-not-a-property-foo" in msg for msg in collector.errors
+            )
+        finally:
+            os.unlink(path)
+
+
+# ── VideoInfo + codec detection ────────────────────────────────────────
+
+
+@requires_gst_runtime
+class TestVideoInfo:
+    def test_wait_for_video_info_returns_info(self):
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as f:
+            path = f.name
+        demuxer = None
+        try:
+            _make_h264_mp4(path, 3)
+            demuxer = UriDemuxer(_file_uri(path), lambda _o: None)
+            info = demuxer.wait_for_video_info(5_000)
+            assert info is not None
+            assert isinstance(info, VideoInfo)
+            assert info.codec == Codec.H264
+            assert info.width > 0
+            assert info.height > 0
+            assert demuxer.video_info is not None
+            assert demuxer.video_info.codec == Codec.H264
+        finally:
+            if demuxer is not None:
+                demuxer.finish()
+            os.unlink(path)
+
+    def test_detected_codec_is_h264(self):
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as f:
+            path = f.name
+        try:
+            _make_h264_mp4(path, 2)
+            collector = PacketCollector()
+            demuxer = UriDemuxer(_file_uri(path), collector)
+            demuxer.wait()
+            assert demuxer.detected_codec == Codec.H264
+        finally:
+            os.unlink(path)
+
+
+# ── Finalization ─────────────────────────────────────────────────────────
+
+
+@requires_gst_runtime
+class TestFinalization:
+    def test_double_finish_is_safe(self):
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as f:
+            path = f.name
+        try:
+            _make_h264_mp4(path, 1)
+            demuxer = UriDemuxer(_file_uri(path), PacketCollector())
+            demuxer.finish()
+            demuxer.finish()
+        finally:
+            os.unlink(path)
+
+    def test_is_finished_property(self):
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as f:
+            path = f.name
+        try:
+            _make_h264_mp4(path, 1)
+            demuxer = UriDemuxer(_file_uri(path), PacketCollector())
+            assert not demuxer.is_finished
+            demuxer.finish()
+            assert demuxer.is_finished
+        finally:
+            os.unlink(path)
+
+
+# ── Round-trip ─────────────────────────────────────────────────────────
+
+
+@requires_gst_runtime
+class TestRoundTrip:
+    def test_pts_monotonic(self):
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as f:
+            path = f.name
+        try:
+            _make_h264_mp4(path, 8)
+            collector = PacketCollector()
+            demuxer = UriDemuxer(_file_uri(path), collector)
+            demuxer.wait()
+            pts = [p.pts_ns for p in collector.packets]
+            assert len(pts) >= 1
+            for i in range(1, len(pts)):
+                assert pts[i] >= pts[i - 1]
+        finally:
+            os.unlink(path)
+
+
+# ── Parity with Mp4Demuxer (ground truth) ───────────────────────────────
+
+
+def _iter_annex_b_nals(buf: bytes) -> List[bytes]:
+    """Split an Annex-B byte stream into raw NAL units (no start codes).
+
+    Supports both 3-byte (``00 00 01``) and 4-byte (``00 00 00 01``) start
+    codes. Mirrors the logic in savant_gstreamer's Rust parity test.
+    """
+    out: List[bytes] = []
+    n = len(buf)
+
+    def find_start(k: int):
+        while k + 3 <= n:
+            if buf[k] == 0 and buf[k + 1] == 0 and buf[k + 2] == 1:
+                return (k, 3)
+            if (
+                k + 4 <= n
+                and buf[k] == 0
+                and buf[k + 1] == 0
+                and buf[k + 2] == 0
+                and buf[k + 3] == 1
+            ):
+                return (k, 4)
+            k += 1
+        return None
+
+    first = find_start(0)
+    if first is None:
+        return out
+    start, prefix = first
+    i = start + prefix
+    while i < n:
+        nxt = find_start(i)
+        if nxt is None:
+            out.append(bytes(buf[i:]))
+            break
+        next_start, next_prefix = nxt
+        out.append(bytes(buf[i:next_start]))
+        i = next_start + next_prefix
+    return out
+
+
+def _h264_slice_nals(au: bytes) -> List[bytes]:
+    """Strip AUD / SPS / PPS / SEI / filler NALs from an H.264 access unit.
+
+    The two demuxers insert configuration NAL preambles slightly
+    differently (parsebin vs qtdemux + h264parse), but the actual slice
+    NALs must be byte-identical. See savant_gstreamer/tests/demuxer_parity.rs.
+    """
+    out: List[bytes] = []
+    for nal in _iter_annex_b_nals(au):
+        if not nal:
+            continue
+        # H.264 NAL header: forbidden_zero_bit (1), nal_ref_idc (2), nal_unit_type (5).
+        nal_type = nal[0] & 0x1F
+        # 9 = AUD, 7 = SPS, 8 = PPS, 6 = SEI, 12 = FillerData,
+        # 10 = SeqEnd, 11 = StreamEnd, 13 = SpsExt, 15 = SubsetSps.
+        if nal_type in (6, 7, 8, 9, 10, 11, 12, 13, 15):
+            continue
+        out.append(nal)
+    return out
+
+
+def _collect_via_mp4(path: str):
+    collector = PacketCollector()
+    demuxer = Mp4Demuxer(path, collector, parsed=True)
+    demuxer.wait()
+    return collector.packets, demuxer.video_info, demuxer.detected_codec
+
+
+def _collect_via_uri(path: str):
+    collector = PacketCollector()
+    demuxer = UriDemuxer(_file_uri(path), collector, parsed=True)
+    demuxer.wait()
+    return collector.packets, demuxer.video_info, demuxer.detected_codec
+
+
+@requires_gst_runtime
+class TestMp4DemuxerParity:
+    """Cross-check UriDemuxer against Mp4Demuxer on the same file."""
+
+    def _assert_video_info_equal(self, a: VideoInfo, b: VideoInfo) -> None:
+        assert a.codec == b.codec
+        assert a.width == b.width
+        assert a.height == b.height
+        assert a.framerate_num == b.framerate_num
+        assert a.framerate_den == b.framerate_den
+
+    def test_h264_parity(self):
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as f:
+            path = f.name
+        try:
+            _make_h264_mp4(path, 10)
+
+            mp4_pkts, mp4_info, mp4_codec = _collect_via_mp4(path)
+            uri_pkts, uri_info, uri_codec = _collect_via_uri(path)
+
+            assert mp4_codec == uri_codec == Codec.H264
+            assert mp4_info is not None and uri_info is not None
+            self._assert_video_info_equal(mp4_info, uri_info)
+
+            assert len(mp4_pkts) == len(uri_pkts), (
+                f"packet count mismatch: mp4={len(mp4_pkts)} uri={len(uri_pkts)}"
+            )
+            assert len(mp4_pkts) >= 1
+
+            for idx, (r, u) in enumerate(zip(mp4_pkts, uri_pkts)):
+                assert r.pts_ns == u.pts_ns, f"packet[{idx}] pts_ns differ"
+                assert r.is_keyframe == u.is_keyframe, (
+                    f"packet[{idx}] is_keyframe differ"
+                )
+                if r.dts_ns is not None and u.dts_ns is not None:
+                    assert r.dts_ns == u.dts_ns, f"packet[{idx}] dts_ns differ"
+                if r.duration_ns is not None and u.duration_ns is not None:
+                    assert r.duration_ns == u.duration_ns, (
+                        f"packet[{idx}] duration_ns differ"
+                    )
+
+                r_slices = _h264_slice_nals(r.data)
+                u_slices = _h264_slice_nals(u.data)
+                assert r_slices == u_slices, (
+                    f"packet[{idx}] slice NALs differ"
+                )
+                assert r_slices, f"packet[{idx}] has no slice NALs"
+        finally:
+            os.unlink(path)

--- a/savant_python/python/savant_rs/deepstream/deepstream.pyi
+++ b/savant_python/python/savant_rs/deepstream/deepstream.pyi
@@ -56,6 +56,7 @@ __all__ = [
     "SourceEosOutput",
     "EventOutput",
     "ErrorOutput",
+    "RestartedOutput",
     "FlexibleDecoderOutput",
     "FlexibleDecoder",
     "EvictionDecision",
@@ -1351,6 +1352,8 @@ class SkipReason:
     @property
     def is_decoder_creation_failed(self) -> bool: ...
     @property
+    def is_decoder_restarted(self) -> bool: ...
+    @property
     def detail(self) -> Optional[str]:
         """Human-readable detail for string-carrying variants, or ``None``."""
         ...
@@ -1538,6 +1541,33 @@ class ErrorOutput:
     def __repr__(self) -> str: ...
 
 @final
+class RestartedOutput:
+    """Aggregate signal emitted when the FlexibleDecoder transparently
+    restarted after the underlying NvDecoder worker died (e.g. a watchdog
+    trip)."""
+
+    @property
+    def source_id(self) -> str:
+        """Source id of the FlexibleDecoder that restarted."""
+        ...
+
+    @property
+    def reason(self) -> str:
+        """Human-readable reason for the restart."""
+        ...
+
+    @property
+    def lost_frames(self) -> int:
+        """Number of in-flight frames lost because of the restart.
+
+        Each is also surfaced separately as a :class:`SkippedOutput` with
+        :class:`SkipReason` ``DecoderRestarted``.
+        """
+        ...
+
+    def __repr__(self) -> str: ...
+
+@final
 class FlexibleDecoderOutput:
     """Callback payload from :class:`FlexibleDecoder`.
 
@@ -1564,6 +1594,8 @@ class FlexibleDecoderOutput:
     def is_event(self) -> bool: ...
     @property
     def is_error(self) -> bool: ...
+    @property
+    def is_restarted(self) -> bool: ...
 
     def as_frame(self) -> Optional[FrameOutput]:
         """Downcast to :class:`FrameOutput`, or ``None``."""
@@ -1591,6 +1623,10 @@ class FlexibleDecoderOutput:
 
     def as_error(self) -> Optional[ErrorOutput]:
         """Downcast to :class:`ErrorOutput`, or ``None``."""
+        ...
+
+    def as_restarted(self) -> Optional[RestartedOutput]:
+        """Downcast to :class:`RestartedOutput`, or ``None``."""
         ...
 
     def __repr__(self) -> str: ...

--- a/savant_python/python/savant_rs/gstreamer/gstreamer.pyi
+++ b/savant_python/python/savant_rs/gstreamer/gstreamer.pyi
@@ -10,7 +10,7 @@ import Codec`` imports keep working.
 
 from __future__ import annotations
 
-from typing import Callable, Optional, Union, final
+from typing import Callable, Dict, Optional, Union, final
 
 from savant_rs.primitives import Codec
 
@@ -23,7 +23,11 @@ __all__ = [
     "VideoInfo",
     "Mp4DemuxerOutput",
     "Mp4Demuxer",
+    "UriDemuxer",
 ]
+
+# Scalar types accepted in ``UriDemuxer`` property dicts.
+_PropValue = Union[bool, int, float, str, bytes]
 
 # ── Always available ─────────────────────────────────────────────────────
 
@@ -314,6 +318,118 @@ class Mp4Demuxer:
         """Shut down the demuxer pipeline.
 
         Safe to call multiple times.  After this call, no more callbacks
+        will fire.
+
+        Must **not** be called from within the ``result_callback``.
+        """
+        ...
+
+    @property
+    def is_finished(self) -> bool:
+        """Whether the demuxer has been finalized."""
+        ...
+
+class UriDemuxer:
+    """Callback-based GStreamer URI demuxer:
+    ``urisourcebin -> parsebin -> [byte-stream capsfilter] -> queue -> appsink``
+    (requires ``gst`` feature).
+
+    Reads encoded elementary video packets from any GStreamer-supported URI
+    (``file://``, ``http(s)://``, ``rtsp://``, HLS, DASH, MKV, TS, MP4, ...)
+    without decoding. The callback receives :class:`Mp4DemuxerOutput`
+    instances — the same Python class used by :class:`Mp4Demuxer` — so
+    consumer code is identical across the two demuxers.
+
+    When ``parsed=True`` (the default), codec-specific parsers emit
+    byte-stream (Annex-B) H.264/HEVC output; otherwise parsebin-native
+    output passes through.
+
+    **Threading**: the callback fires on GStreamer's internal streaming
+    thread.  Do **not** call :meth:`finish` from within the callback.
+
+    Args:
+        uri: Source URI (non-empty). See `gst-launch-1.0 urisourcebin`
+            for the list of supported schemes.
+        result_callback: ``Callable[[Mp4DemuxerOutput], None]`` invoked for
+            stream-info, packet, EOS, or error outputs.
+        parsed: If ``True``, emit byte-stream output for H.264/HEVC.
+            Defaults to ``True``.
+        bin_properties: Optional ``{name: value}`` dict of properties applied
+            to the ``urisourcebin`` element (e.g.
+            ``{"buffer-size": 8_388_608}``).
+            Values must be ``bool``, ``int``, ``float``, ``str``, or ``bytes``.
+            An unsupported value type raises :class:`TypeError`; an unknown
+            property name raises :class:`RuntimeError`.
+        source_properties: Optional ``{name: value}`` dict applied to the
+            inner source element autoplugged by ``urisourcebin`` (e.g.
+            ``rtspsrc``, ``souphttpsrc``) through the ``source-setup``
+            signal. Failures to set individual source properties are
+            surfaced as error outputs to ``result_callback`` (they do not
+            abort construction).
+
+    Raises:
+        RuntimeError: If the URI is missing / malformed, if pipeline
+            construction fails, or if a *bin* property cannot be applied.
+        TypeError: If a value in ``bin_properties`` / ``source_properties``
+            has an unsupported type.
+    """
+
+    def __init__(
+        self,
+        uri: str,
+        result_callback: Callable[[Mp4DemuxerOutput], None],
+        parsed: bool = True,
+        bin_properties: Optional[Dict[str, _PropValue]] = None,
+        source_properties: Optional[Dict[str, _PropValue]] = None,
+    ) -> None: ...
+    def wait(self) -> None:
+        """Block until the demuxer reaches EOS, encounters an error, or
+        :meth:`finish` is called.
+
+        The GIL is released while waiting so the callback can fire.
+        """
+        ...
+
+    def wait_timeout(self, timeout_ms: int) -> bool:
+        """Block until the demuxer finishes or the timeout expires.
+
+        Args:
+            timeout_ms: Timeout in milliseconds.
+
+        Returns:
+            ``True`` if finished, ``False`` on timeout.
+        """
+        ...
+
+    @property
+    def detected_codec(self) -> Optional[Codec]:
+        """Auto-detected video codec, or ``None``."""
+        ...
+
+    @property
+    def video_info(self) -> Optional[VideoInfo]:
+        """Auto-detected :class:`VideoInfo`, or ``None``."""
+        ...
+
+    def wait_for_video_info(self, timeout_ms: int) -> Optional[VideoInfo]:
+        """Block until :class:`VideoInfo` is known, the pipeline terminates,
+        or the timeout expires.
+
+        Args:
+            timeout_ms: Timeout in milliseconds.
+
+        Returns:
+            The detected :class:`VideoInfo`, or ``None`` on timeout / early
+            termination.
+
+        The GIL is released while waiting.
+        """
+        ...
+
+    def finish(self) -> None:
+        """Shut down the demuxer pipeline.
+
+        Safe to call multiple times. After this call, no more callbacks
         will fire.
 
         Must **not** be called from within the ``result_callback``.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new URI-based demuxing path (Rust + Python + framework templates) and changes FlexibleDecoder’s buffering/restart behavior, which can affect streaming stability and callback semantics. Risk is moderated by extensive new tests but touches core media ingest and decoder lifecycle logic.
> 
> **Overview**
> Adds a new GStreamer `UriDemuxer` (driven by `urisourcebin`/`parsebin`) with shared demux types (`demux::DemuxedPacket`/`VideoInfo`), parity tests against `Mp4Demuxer`, and Python bindings (`savant_rs.gstreamer.UriDemuxer`) including configurable bin/source properties.
> 
> Updates `FlexibleDecoder` to avoid replaying pre-IDR buffered packets (now surfaced as `Skipped(WaitingForKeyframe)`), to treat worker death as a transparent restart that drains in-flight frames as `Skipped(DecoderRestarted)` and emits a new aggregate `Restarted` output (also exposed in Python). Improves diagnostics around sealed deliveries by giving `ReleaseSeal` unique IDs and making `Sealed::unseal` warn periodically when blocked, with added regression tests.
> 
> Extends the `cars_demo` pipeline/CLI to accept either a file path or a URI and dispatch to the appropriate demuxer stage (`StageKind::UriDemux`), and updates `deepstream-tests` crate coverage in the `Makefile`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c308d323d8cbacfa66e3fbe023cb05dd1d7395a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->