### PR TITLE
Demuxer video stream linking

### DIFF
--- a/savant_gstreamer/savant_gstreamer/src/uri_demuxer.rs
+++ b/savant_gstreamer/savant_gstreamer/src/uri_demuxer.rs
@@ -512,9 +512,40 @@ impl UriDemuxer {
                     return;
                 };
                 if parse_sink.is_linked() {
-                    // More than one stream from urisourcebin; parsebin already handles one.
                     return;
                 }
+
+                // For multi-stream sources (e.g. RTSP), urisourcebin emits
+                // separate pads per stream.  Only link non-audio pads so that
+                // an audio pad arriving first does not steal the single
+                // parsebin sink slot and cause the video stream to be dropped.
+                let is_audio = src_pad
+                    .current_caps()
+                    .or_else(|| Some(src_pad.query_caps(None)))
+                    .and_then(|caps| {
+                        caps.structure(0).map(|s| {
+                            let name = s.name();
+                            if name.starts_with("audio/") {
+                                return true;
+                            }
+                            if name == "application/x-rtp" {
+                                if let Ok(media) = s.get::<&str>("media") {
+                                    return media == "audio";
+                                }
+                            }
+                            false
+                        })
+                    })
+                    .unwrap_or(false);
+
+                if is_audio {
+                    log::debug!(
+                        "UriDemuxer: skipping audio urisourcebin pad {}",
+                        src_pad.name()
+                    );
+                    return;
+                }
+
                 if let Err(e) = src_pad.link(&parse_sink) {
                     on_output_uri_pad(UriDemuxerOutput::Error(UriDemuxerError::LinkError(
                         format!("urisourcebin->parsebin: {e}"),

--- a/savant_gstreamer/savant_gstreamer/src/uri_demuxer.rs
+++ b/savant_gstreamer/savant_gstreamer/src/uri_demuxer.rs
@@ -515,22 +515,23 @@ impl UriDemuxer {
                     return;
                 }
 
-                // For multi-stream sources (e.g. RTSP), urisourcebin emits
-                // separate pads per stream.  Only link non-audio pads so that
-                // an audio pad arriving first does not steal the single
-                // parsebin sink slot and cause the video stream to be dropped.
-                let is_audio = src_pad
+                // For multi-stream sources (e.g. RTSP, MKV, TS, DASH),
+                // urisourcebin emits separate pads per stream.  Only link
+                // video-like pads so that a non-video pad (audio, subtitle,
+                // data) arriving first does not steal the single parsebin
+                // sink slot and cause the video stream to be dropped.
+                let is_video = src_pad
                     .current_caps()
                     .or_else(|| Some(src_pad.query_caps(None)))
                     .and_then(|caps| {
                         caps.structure(0).map(|s| {
                             let name = s.name();
-                            if name.starts_with("audio/") {
+                            if name.starts_with("video/") || name.starts_with("image/") {
                                 return true;
                             }
                             if name == "application/x-rtp" {
                                 if let Ok(media) = s.get::<&str>("media") {
-                                    return media == "audio";
+                                    return media == "video";
                                 }
                             }
                             false
@@ -538,9 +539,9 @@ impl UriDemuxer {
                     })
                     .unwrap_or(false);
 
-                if is_audio {
+                if !is_video {
                     log::debug!(
-                        "UriDemuxer: skipping audio urisourcebin pad {}",
+                        "UriDemuxer: skipping non-video urisourcebin pad {}",
                         src_pad.name()
                     );
                     return;


### PR DESCRIPTION
Filter `urisourcebin` pads by media type to ensure video streams are linked for multi-stream sources like RTSP.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes stream-selection behavior for multi-stream URIs by filtering pads based on caps, which could inadvertently skip uncommon video caps or alter which stream is chosen in edge cases.
> 
> **Overview**
> Prevents `UriDemuxer` from accidentally linking a non-video stream (audio/subtitles/data) into the single `parsebin` sink when `urisourcebin` exposes multiple pads (e.g., RTSP/MKV/TS/DASH).
> 
> The `urisourcebin::pad-added` handler now inspects pad caps and only links video/image pads (including `application/x-rtp` with `media=video`), logging and skipping other pad types so the video stream isn’t dropped if a non-video pad appears first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 408791092179cff336b94e33d2a670c8efa489b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->